### PR TITLE
feat: add multi-table, time-series, and logging support (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.0] - 2026-04-13
+
+### Added
+
+- **Multi-table synthesis**: `Table` class and `dataxid.synthesize_tables()` for generating related tables with referential integrity
+- **Sequential / time-series generation**: automatic per-entity sequence modeling when foreign keys are present (`sequential`, `sequence_by`)
+- **Context-aware generation**: `parent`, `parent_key`, `foreign_key` parameters on `synthesize()` and `Model.create()`
+- **Datetime auto-detection**: heuristic that detects datetime columns by name patterns and value sampling
+- **SDK logging**: `dataxid.enable_logging()` / `disable_logging()` and `DATAXID_LOG` env var (default off, sensitive headers masked)
+- Multi-table quickstart example (`examples/multitable.py`)
+
 ## [0.1.0] - 2026-03-10
 
 ### Added
@@ -21,4 +32,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Automatic retry with exponential backoff and `Retry-After` support
 - `DATAXID_API_KEY` environment variable support
 
+[0.2.0]: https://github.com/dataxid/dataxid-python/releases/tag/v0.2.0
 [0.1.0]: https://github.com/dataxid/dataxid-python/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Dataxid Python SDK
+# DataXID Python SDK
 
 [![PyPI version](https://img.shields.io/pypi/v/dataxid)](https://pypi.org/project/dataxid/)
 [![Python versions](https://img.shields.io/pypi/pyversions/dataxid)](https://pypi.org/project/dataxid/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/dataxid/dataxid-python/blob/main/LICENSE)
 
-Privacy-preserving synthetic data generation, built on a privacy-by-architecture principle. Your raw data never leaves your machine — only abstract embeddings are shared with the API.
+High-fidelity synthetic data generation for single-table, multi-table, and time series data.
 
 ## Installation
 
@@ -20,11 +20,46 @@ import pandas as pd
 
 dataxid.api_key = "dx_..."
 
-df = pd.read_csv("data.csv")
+df = pd.read_csv("customers.csv")
 synthetic = dataxid.synthesize(data=df, n_samples=1000)
 ```
 
-## Full Control
+## Multi-Table & Time Series
+
+Synthesize related tables with referential integrity. Child tables are
+generated sequentially by default — preserving realistic per-entity
+patterns like transaction counts, temporal ordering, and sequence lengths.
+
+```python
+from dataxid import Table
+
+accounts = Table(pd.read_csv("accounts.csv"), primary_key="account_id")
+transactions = Table(pd.read_csv("transactions.csv"),
+                     foreign_keys={"account_id": accounts})
+
+synthetic = dataxid.synthesize_tables({
+    "accounts": accounts,
+    "transactions": transactions,
+})
+
+synthetic["accounts"]       # synthetic accounts with auto-assigned PKs
+synthetic["transactions"]   # sequential transactions per account, valid FKs
+```
+
+## How It Works
+
+Dataxid is built on a **privacy-by-architecture** principle. Data encoding and decoding happen entirely on your machine; only abstract embeddings are shared with the API for model training. Raw data never leaves your environment.
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `embedding_dim` | `64` | Embedding size (larger = more expressive) |
+| `model_size` | `"medium"` | Model capacity: `"small"`, `"medium"`, `"large"` |
+| `max_epochs` | `100` | Maximum training epochs |
+| `batch_size` | `256` | Training batch size |
+| `privacy_enabled` | `False` | Add noise to embeddings for privacy |
+| `privacy_noise` | `0.1` | Noise scale (Gaussian std) |
 
 ```python
 import dataxid
@@ -32,10 +67,29 @@ import pandas as pd
 
 dataxid.api_key = "dx_..."
 
-df = pd.read_csv("data.csv")
+df = pd.read_csv("customers.csv")
 
-model = dataxid.Model.create(data=df)
+model = dataxid.Model.create(
+    data=df,
+    config=dataxid.ModelConfig(
+        embedding_dim=128,
+        model_size="large",
+        max_epochs=50,
+    ),
+)
 synthetic = model.generate(n_samples=1000)
+model.delete()
+```
+
+`synthesize_tables` handles orchestration automatically. Use `Model.create` for fine-grained control:
+
+```python
+model = dataxid.Model.create(
+    data=transactions_df,
+    parent=accounts_df,
+    foreign_key="account_id",
+)
+synthetic = model.generate(parent=synthetic_accounts_df)
 model.delete()
 ```
 
@@ -56,44 +110,8 @@ except dataxid.DataxidError as e:
     print(f"Error: {e}")
 ```
 
-## How It Works
-
-Dataxid is built on a **privacy-by-architecture** principle. Data encoding and decoding happen entirely on your machine; only abstract embeddings are shared with the API for model training. Raw data never leaves your environment.
-
-## Configuration
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `embedding_dim` | `64` | Embedding size (larger = more expressive) |
-| `model_size` | `"medium"` | Model capacity: `"small"`, `"medium"`, `"large"` |
-| `max_epochs` | `100` | Maximum training epochs |
-| `batch_size` | `256` | Training batch size |
-| `privacy_enabled` | `False` | Add noise to embeddings for privacy |
-| `privacy_noise` | `0.1` | Noise scale (Gaussian std) |
-
-```python
-model = dataxid.Model.create(
-    data=df,
-    config=dataxid.ModelConfig(
-        embedding_dim=128,
-        model_size="large",
-        max_epochs=50,
-    ),
-)
-```
-
-Plain dict also works for quick experiments:
-
-```python
-model = dataxid.Model.create(
-    data=df,
-    config={"embedding_dim": 128, "max_epochs": 50},
-)
-```
-
 ## Links
 
 - [Documentation](https://docs.dataxid.com)
 - [API Reference](https://docs.dataxid.com/docs/api-reference)
 - [GitHub](https://github.com/dataxid/dataxid-python)
-- [Examples](examples/quickstart.py)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ import dataxid
 import pandas as pd
 
 dataxid.api_key = "dx_..."
+dataxid.enable_logging("info")  # optional: see training progress
 
 df = pd.read_csv("customers.csv")
 synthetic = dataxid.synthesize(data=df, n_samples=1000)
@@ -91,6 +92,20 @@ model = dataxid.Model.create(
 )
 synthetic = model.generate(parent=synthetic_accounts_df)
 model.delete()
+```
+
+## Logging
+
+```python
+dataxid.enable_logging("info")   # see training progress, epoch stats
+dataxid.enable_logging("debug")  # verbose: includes HTTP requests
+dataxid.disable_logging()        # turn off (default state)
+```
+
+Or via environment variable (no code change needed):
+
+```bash
+DATAXID_LOG=info python my_script.py
 ```
 
 ## Error Handling

--- a/dataxid/__init__.py
+++ b/dataxid/__init__.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import pandas as pd
 
+from dataxid._table import Table
 from dataxid.exceptions import (
     APIError,
     AuthenticationError,
@@ -55,6 +56,10 @@ def synthesize(
     config: dict | ModelConfig | None = None,
     api_key: str | None = None,
     base_url: str | None = None,
+    parent: pd.DataFrame | None = None,
+    parent_encoding_types: dict[str, str] | None = None,
+    group_by: str | None = None,
+    parent_key: str | None = None,
 ) -> pd.DataFrame:
     """
     Generate synthetic data in one call.
@@ -74,9 +79,13 @@ def synthesize(
         config: Training config (model_size, embedding_dim, max_epochs, etc.)
         api_key: Override dataxid.api_key
         base_url: Override dataxid.base_url
+        parent: Parent table for context-aware generation (1:1 aligned or joined via group_by)
+        parent_encoding_types: Encoding overrides for parent columns
+        group_by: Column in data linking rows to parent entities (enables sequential mode)
+        parent_key: Primary key column in parent table
 
     Returns:
-        DataFrame with synthetic data
+        DataFrame with synthetic data (target columns only)
     """
     model = Model.create(
         data=data,
@@ -84,6 +93,10 @@ def synthesize(
         config=config,
         api_key=api_key,
         base_url=base_url,
+        parent=parent,
+        parent_encoding_types=parent_encoding_types,
+        group_by=group_by,
+        parent_key=parent_key,
     )
     try:
         return model.generate(n_samples=n_samples)
@@ -96,10 +109,120 @@ def synthesize(
         model.delete()
 
 
+def synthesize_tables(
+    tables: dict[str, Table],
+    config: dict | ModelConfig | None = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> dict[str, pd.DataFrame]:
+    """
+    Synthesize multiple related tables with referential integrity.
+
+    Trains and generates each table in dependency order (parents first).
+    Primary keys are excluded from training and auto-assigned after generation.
+    Foreign keys in child tables reference the synthetic parent's primary keys.
+
+    Example::
+
+        from dataxid import Table
+
+        syn = dataxid.synthesize_tables({
+            "accounts": Table(accounts_df, primary_key="account_id"),
+            "transactions": Table(
+                transactions_df, references={"account_id": "accounts"}
+            ),
+        })
+        syn["accounts"]       # synthetic accounts with auto-assigned PK
+        syn["transactions"]   # synthetic transactions with valid FK references
+
+    Args:
+        tables: Mapping of table name to Table definition.
+        config: Training config applied to all tables.
+        api_key: Override dataxid.api_key.
+        base_url: Override dataxid.base_url.
+
+    Returns:
+        Dict mapping table name to synthetic DataFrame.
+    """
+    from dataxid._table import (
+        _assign_primary_keys,
+        _remap_foreign_keys,
+        _topological_sort,
+        _validate_tables,
+    )
+
+    _validate_tables(tables)
+    order = _topological_sort(tables)
+    assert order is not None  # _validate_tables guarantees no cycles
+
+    results: dict[str, pd.DataFrame] = {}
+
+    for name in order:
+        tbl = tables[name]
+        pk_col = tbl.primary_key
+        parent_refs = tbl.references
+
+        training_data = tbl.data
+        if pk_col is not None:
+            training_data = training_data.drop(columns=[pk_col])
+
+        ctx_fk = tbl.context_key
+        if ctx_fk:
+            parent_name = parent_refs[ctx_fk]
+            parent_tbl = tables[parent_name]
+            parent_syn = results[parent_name]
+
+            real_parent = parent_tbl.data
+            model = Model.create(
+                data=training_data,
+                config=config,
+                api_key=api_key,
+                base_url=base_url,
+                parent=real_parent,
+                parent_key=parent_tbl.primary_key,
+                group_by=ctx_fk,
+            )
+            try:
+                syn_df = model.generate(parent=parent_syn)
+            except Exception:
+                _logger.warning(
+                    "generate() failed for table '%s' — deleting model %s and re-raising.",
+                    name, model.id,
+                )
+                raise
+            finally:
+                model.delete()
+        else:
+            syn_df = synthesize(
+                data=training_data,
+                n_samples=len(tbl.data),
+                config=config,
+                api_key=api_key,
+                base_url=base_url,
+            )
+
+        for fk_c, par_name in parent_refs.items():
+            if fk_c == ctx_fk:
+                continue
+            par_syn = results[par_name]
+            par_pk = tables[par_name].primary_key
+            if par_pk is not None:
+                syn_df = _remap_foreign_keys(syn_df, fk_c, par_syn, par_pk)
+
+        if pk_col is not None:
+            syn_df = _assign_primary_keys(syn_df, pk_col)
+
+        results[name] = syn_df
+
+    return results
+
+
 __all__ = [
     "api_key",
     "base_url",
     "synthesize",
+    "synthesize_tables",
+    "Table",
     "Model",
     "ModelConfig",
     "DataxidError",

--- a/dataxid/__init__.py
+++ b/dataxid/__init__.py
@@ -19,7 +19,7 @@ Quick start::
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from typing import TYPE_CHECKING
 

--- a/dataxid/__init__.py
+++ b/dataxid/__init__.py
@@ -58,7 +58,7 @@ def synthesize(
     base_url: str | None = None,
     parent: pd.DataFrame | None = None,
     parent_encoding_types: dict[str, str] | None = None,
-    group_by: str | None = None,
+    foreign_key: str | None = None,
     parent_key: str | None = None,
 ) -> pd.DataFrame:
     """
@@ -79,10 +79,10 @@ def synthesize(
         config: Training config (model_size, embedding_dim, max_epochs, etc.)
         api_key: Override dataxid.api_key
         base_url: Override dataxid.base_url
-        parent: Parent table for context-aware generation (1:1 aligned or joined via group_by)
+        parent: Parent table for context-aware generation (1:1 aligned or joined via foreign_key)
         parent_encoding_types: Encoding overrides for parent columns
-        group_by: Column in data linking rows to parent entities (enables sequential mode)
-        parent_key: Primary key column in parent table
+        foreign_key: FK column in data linking rows to parent (enables sequential mode)
+        parent_key: PK column in parent table (inferred from foreign_key if same name)
 
     Returns:
         DataFrame with synthetic data (target columns only)
@@ -95,7 +95,7 @@ def synthesize(
         base_url=base_url,
         parent=parent,
         parent_encoding_types=parent_encoding_types,
-        group_by=group_by,
+        foreign_key=foreign_key,
         parent_key=parent_key,
     )
     try:
@@ -126,11 +126,13 @@ def synthesize_tables(
 
         from dataxid import Table
 
+        accounts = Table(accounts_df, primary_key="account_id")
+        transactions = Table(transactions_df,
+                             foreign_keys={"account_id": accounts})
+
         syn = dataxid.synthesize_tables({
-            "accounts": Table(accounts_df, primary_key="account_id"),
-            "transactions": Table(
-                transactions_df, references={"account_id": "accounts"}
-            ),
+            "accounts": accounts,
+            "transactions": transactions,
         })
         syn["accounts"]       # synthetic accounts with auto-assigned PK
         syn["transactions"]   # synthetic transactions with valid FK references
@@ -147,6 +149,7 @@ def synthesize_tables(
     from dataxid._table import (
         _assign_primary_keys,
         _remap_foreign_keys,
+        _resolve_fk_targets,
         _topological_sort,
         _validate_tables,
     )
@@ -154,21 +157,22 @@ def synthesize_tables(
     _validate_tables(tables)
     order = _topological_sort(tables)
     assert order is not None  # _validate_tables guarantees no cycles
+    fk_targets = _resolve_fk_targets(tables)
 
     results: dict[str, pd.DataFrame] = {}
 
     for name in order:
         tbl = tables[name]
         pk_col = tbl.primary_key
-        parent_refs = tbl.references
+        resolved_fks = fk_targets[name]
 
         training_data = tbl.data
         if pk_col is not None:
             training_data = training_data.drop(columns=[pk_col])
 
-        ctx_fk = tbl.context_key
+        ctx_fk = _pick_context_fk(tbl)
         if ctx_fk:
-            parent_name = parent_refs[ctx_fk]
+            parent_name = resolved_fks[ctx_fk]
             parent_tbl = tables[parent_name]
             parent_syn = results[parent_name]
 
@@ -180,7 +184,7 @@ def synthesize_tables(
                 base_url=base_url,
                 parent=real_parent,
                 parent_key=parent_tbl.primary_key,
-                group_by=ctx_fk,
+                foreign_key=ctx_fk,
             )
             try:
                 syn_df = model.generate(parent=parent_syn)
@@ -201,7 +205,7 @@ def synthesize_tables(
                 base_url=base_url,
             )
 
-        for fk_c, par_name in parent_refs.items():
+        for fk_c, par_name in resolved_fks.items():
             if fk_c == ctx_fk:
                 continue
             par_syn = results[par_name]
@@ -215,6 +219,21 @@ def synthesize_tables(
         results[name] = syn_df
 
     return results
+
+
+def _pick_context_fk(tbl: Table) -> str | None:
+    """Determine which FK column to use as sequential context.
+
+    Returns None if the table has no foreign_keys or sequential=False.
+    For single FK → that FK. For multiple FKs → sequence_by (validated by Table).
+    """
+    if not tbl.foreign_keys or not tbl.sequential:
+        return None
+    if tbl.sequence_by:
+        return tbl.sequence_by
+    if len(tbl.foreign_keys) == 1:
+        return next(iter(tbl.foreign_keys))
+    return None
 
 
 __all__ = [

--- a/dataxid/__init__.py
+++ b/dataxid/__init__.py
@@ -21,12 +21,14 @@ from __future__ import annotations
 
 __version__ = "0.1.0"
 
-import logging as _logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import pandas as pd
 
+from dataxid._log import disable_logging, enable_logging
+from dataxid._log import logger as _logger
+from dataxid._log import setup_logging as _setup_logging
 from dataxid._table import Table
 from dataxid.exceptions import (
     APIError,
@@ -44,10 +46,11 @@ from dataxid.exceptions import (
 from dataxid.training._config import ModelConfig
 from dataxid.training._model import Model
 
-_logger = _logging.getLogger("dataxid")
-
 api_key: str | None = None
 base_url: str = "https://api.dataxid.com"
+
+
+_setup_logging()
 
 
 def synthesize(
@@ -237,6 +240,8 @@ def _pick_context_fk(tbl: Table) -> str | None:
 
 
 __all__ = [
+    "enable_logging",
+    "disable_logging",
     "api_key",
     "base_url",
     "synthesize",

--- a/dataxid/_log.py
+++ b/dataxid/_log.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import logging
+import os
+
+logger: logging.Logger = logging.getLogger("dataxid")
+logger.addHandler(logging.NullHandler())
+
+SENSITIVE_HEADERS = {"authorization", "x-api-key"}
+
+_LOG_FORMAT = "[%(asctime)s - %(name)s - %(levelname)s] %(message)s"
+_LOG_DATEFMT = "%Y-%m-%d %H:%M:%S"
+
+
+class SensitiveHeadersFilter(logging.Filter):
+    """Mask sensitive headers (API keys, tokens) in log output."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.args, dict) and "headers" in record.args:
+            headers = record.args["headers"]
+            if isinstance(headers, dict):
+                record.args["headers"] = {
+                    k: "***" if k.lower() in SENSITIVE_HEADERS else v
+                    for k, v in headers.items()
+                }
+        return True
+
+
+def enable_logging(level: str = "info") -> None:
+    """Enable SDK logging at the given level.
+
+    Adds a ``StreamHandler`` to the ``dataxid`` logger (not root).
+    Safe to call multiple times; existing handlers are replaced.
+
+    Args:
+        level: One of "debug", "info", "warning", "error", "critical".
+
+    Raises:
+        ValueError: If *level* is not a valid Python log level name.
+    """
+    numeric = getattr(logging, level.upper(), None)
+    if not isinstance(numeric, int):
+        raise ValueError(
+            f"Invalid log level: {level!r}. "
+            f"Use one of: debug, info, warning, error, critical."
+        )
+
+    logger.setLevel(numeric)
+
+    if not any(isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+               for h in logger.handlers):
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATEFMT))
+        logger.addHandler(handler)
+
+    if not any(isinstance(f, SensitiveHeadersFilter) for f in logger.filters):
+        logger.addFilter(SensitiveHeadersFilter())
+
+
+def disable_logging() -> None:
+    """Disable SDK logging and remove all handlers (except NullHandler)."""
+    logger.setLevel(logging.NOTSET)
+    logger.handlers = [h for h in logger.handlers if isinstance(h, logging.NullHandler)]
+    logger.filters.clear()
+
+
+def setup_logging() -> None:
+    """Activate logging from ``DATAXID_LOG`` env var (if set)."""
+    env = os.environ.get("DATAXID_LOG")
+    if env:
+        enable_logging(env)

--- a/dataxid/_table.py
+++ b/dataxid/_table.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Multi-table synthesis — table definitions and orchestration helpers.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from dataxid.exceptions import InvalidRequestError
+
+# ---------------------------------------------------------------------------
+# Public dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Table:
+    """
+    A table definition for multi-table synthesis.
+
+    Example::
+
+        from dataxid import Table
+
+        Table(districts_df, primary_key="district_id")
+        Table(accounts_df, primary_key="account_id",
+              references={"district_id": "districts"})
+        Table(transactions_df,
+              references={"account_id": "accounts"},
+              context_key="account_id")
+
+    Args:
+        data: Training DataFrame for this table.
+        primary_key: Column name to use as primary key. Excluded from training,
+            auto-assigned after generation (1-based auto-increment).
+        references: Foreign key mapping ``{fk_column: referenced_table_name}``.
+            Ensures referential integrity: FK values in the generated table
+            are remapped to valid synthetic parent PKs.
+        context_key: FK column to use as sequential training context. Must be
+            a key in ``references``. When set, the table is generated
+            conditioned on the parent (one group of rows per parent entity).
+            When ``None`` (default), the table is generated independently
+            and FK columns are only remapped for integrity.
+    """
+
+    data: pd.DataFrame
+    primary_key: str | None = None
+    references: dict[str, str] = field(default_factory=dict)
+    context_key: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.data, pd.DataFrame):
+            raise InvalidRequestError(
+                f"Table.data must be a DataFrame, got {type(self.data).__name__}.",
+                param="data",
+            )
+        if self.primary_key is not None and self.primary_key not in self.data.columns:
+            raise InvalidRequestError(
+                f"primary_key '{self.primary_key}' not found in DataFrame columns: "
+                f"{list(self.data.columns)}.",
+                param="primary_key",
+            )
+        for fk_col in self.references:
+            if fk_col not in self.data.columns:
+                raise InvalidRequestError(
+                    f"Foreign key column '{fk_col}' not found in DataFrame columns: "
+                    f"{list(self.data.columns)}.",
+                    param="references",
+                )
+        if self.context_key is not None and self.context_key not in self.references:
+            raise InvalidRequestError(
+                f"context_key '{self.context_key}' must be one of the references keys: "
+                f"{list(self.references.keys())}.",
+                param="context_key",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def _validate_tables(tables: dict[str, Table]) -> None:
+    """Validate table definitions: FK targets exist, referenced tables have PK, no cycles."""
+    if not tables:
+        raise InvalidRequestError("tables must contain at least one table.", param="tables")
+
+    for name, tbl in tables.items():
+        for fk_col, ref_table in tbl.references.items():
+            if ref_table not in tables:
+                raise InvalidRequestError(
+                    f"Table '{name}' references '{ref_table}' via column '{fk_col}', "
+                    f"but '{ref_table}' is not in tables.",
+                    param="references",
+                )
+            if tables[ref_table].primary_key is None:
+                raise InvalidRequestError(
+                    f"Table '{name}' references '{ref_table}', but '{ref_table}' "
+                    f"has no primary_key defined.",
+                    param="primary_key",
+                )
+
+    order = _topological_sort(tables)
+    if order is None:
+        raise InvalidRequestError(
+            "Circular dependency detected among table references.",
+            param="references",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Topological sort (Kahn's algorithm)
+# ---------------------------------------------------------------------------
+
+def _topological_sort(tables: dict[str, Table]) -> list[str] | None:
+    """Return generation order (parents first) or None if cycle detected."""
+    in_degree: dict[str, int] = {name: 0 for name in tables}
+    dependents: dict[str, list[str]] = {name: [] for name in tables}
+
+    for name, tbl in tables.items():
+        parents = set(tbl.references.values())
+        in_degree[name] = len(parents)
+        for parent in parents:
+            dependents[parent].append(name)
+
+    queue: deque[str] = deque(
+        name for name, deg in in_degree.items() if deg == 0
+    )
+    order: list[str] = []
+
+    while queue:
+        current = queue.popleft()
+        order.append(current)
+        for child in dependents[current]:
+            in_degree[child] -= 1
+            if in_degree[child] == 0:
+                queue.append(child)
+
+    if len(order) != len(tables):
+        return None
+    return order
+
+
+# ---------------------------------------------------------------------------
+# PK / FK helpers
+# ---------------------------------------------------------------------------
+
+def _assign_primary_keys(df: pd.DataFrame, pk_column: str) -> pd.DataFrame:
+    """Insert 1-based auto-increment primary key as first column."""
+    result = df.copy()
+    result.insert(0, pk_column, range(1, len(result) + 1))
+    return result
+
+
+def _remap_foreign_keys(
+    child_df: pd.DataFrame,
+    fk_column: str,
+    parent_df: pd.DataFrame,
+    parent_pk: str,
+) -> pd.DataFrame:
+    """Ensure all FK values in child exist in the synthetic parent's PK domain."""
+    valid_pks = set(parent_df[parent_pk])
+    result = child_df.copy()
+
+    orphan_mask = ~result[fk_column].isin(valid_pks)
+    if orphan_mask.any():
+        pk_values = parent_df[parent_pk].values
+        result.loc[orphan_mask, fk_column] = [
+            pk_values[i % len(pk_values)]
+            for i in range(orphan_mask.sum())
+        ]
+
+    return result

--- a/dataxid/_table.py
+++ b/dataxid/_table.py
@@ -26,31 +26,35 @@ class Table:
 
         from dataxid import Table
 
-        Table(districts_df, primary_key="district_id")
-        Table(accounts_df, primary_key="account_id",
-              references={"district_id": "districts"})
-        Table(transactions_df,
-              references={"account_id": "accounts"},
-              context_key="account_id")
+        districts = Table(districts_df, primary_key="district_id")
+        accounts = Table(accounts_df, primary_key="account_id",
+                         foreign_keys={"district_id": districts})
+        transactions = Table(transactions_df,
+                             foreign_keys={"account_id": accounts})
 
     Args:
         data: Training DataFrame for this table.
         primary_key: Column name to use as primary key. Excluded from training,
             auto-assigned after generation (1-based auto-increment).
-        references: Foreign key mapping ``{fk_column: referenced_table_name}``.
-            Ensures referential integrity: FK values in the generated table
-            are remapped to valid synthetic parent PKs.
-        context_key: FK column to use as sequential training context. Must be
-            a key in ``references``. When set, the table is generated
-            conditioned on the parent (one group of rows per parent entity).
-            When ``None`` (default), the table is generated independently
-            and FK columns are only remapped for integrity.
+        foreign_keys: Foreign key mapping ``{fk_column: parent_Table}``.
+            When ``sequential`` is True (default), the child table is generated
+            conditioned on the parent — preserving correlations. FK values in
+            the generated table are remapped to valid synthetic parent PKs.
+        sequential: When True (default) and ``foreign_keys`` is set, use
+            sequential generation conditioned on the parent. When False,
+            the table is generated independently and FK columns are only
+            remapped for referential integrity.
+        sequence_by: FK column to use as the primary sequential context when
+            the table has multiple foreign keys. Must be a key in
+            ``foreign_keys``. Required when ``len(foreign_keys) > 1`` and
+            ``sequential`` is True; ignored otherwise.
     """
 
     data: pd.DataFrame
     primary_key: str | None = None
-    references: dict[str, str] = field(default_factory=dict)
-    context_key: str | None = None
+    foreign_keys: dict[str, Table] = field(default_factory=dict)
+    sequential: bool = True
+    sequence_by: str | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.data, pd.DataFrame):
@@ -64,19 +68,77 @@ class Table:
                 f"{list(self.data.columns)}.",
                 param="primary_key",
             )
-        for fk_col in self.references:
+        for fk_col, parent_table in self.foreign_keys.items():
             if fk_col not in self.data.columns:
                 raise InvalidRequestError(
                     f"Foreign key column '{fk_col}' not found in DataFrame columns: "
                     f"{list(self.data.columns)}.",
-                    param="references",
+                    param="foreign_keys",
                 )
-        if self.context_key is not None and self.context_key not in self.references:
+            if not isinstance(parent_table, Table):
+                raise InvalidRequestError(
+                    f"foreign_keys values must be Table instances, got "
+                    f"{type(parent_table).__name__} for key '{fk_col}'.",
+                    param="foreign_keys",
+                )
+            if parent_table.primary_key is None:
+                raise InvalidRequestError(
+                    f"Referenced table for '{fk_col}' must have a primary_key defined.",
+                    param="foreign_keys",
+                )
+        if self.sequence_by is not None:
+            if not self.sequential:
+                raise InvalidRequestError(
+                    "sequence_by and sequential=False are mutually exclusive.",
+                    param="sequence_by",
+                )
+            if self.sequence_by not in self.foreign_keys:
+                raise InvalidRequestError(
+                    f"sequence_by '{self.sequence_by}' must be one of the foreign_keys: "
+                    f"{list(self.foreign_keys.keys())}.",
+                    param="sequence_by",
+                )
+        if (
+            self.sequential
+            and len(self.foreign_keys) > 1
+            and self.sequence_by is None
+        ):
             raise InvalidRequestError(
-                f"context_key '{self.context_key}' must be one of the references keys: "
-                f"{list(self.references.keys())}.",
-                param="context_key",
+                f"Table has {len(self.foreign_keys)} foreign keys. Use sequence_by "
+                f"to specify which relationship to use for sequential generation. "
+                f"Options: {list(self.foreign_keys.keys())}.",
+                param="sequence_by",
             )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — resolve Table object references to table names
+# ---------------------------------------------------------------------------
+
+def _build_table_identity(tables: dict[str, Table]) -> dict[int, str]:
+    """Map Table object id → table name for FK resolution."""
+    return {id(tbl): name for name, tbl in tables.items()}
+
+
+def _resolve_fk_targets(
+    tables: dict[str, Table],
+) -> dict[str, dict[str, str]]:
+    """Resolve foreign_keys {fk_col: Table} → {fk_col: parent_name} for each table."""
+    identity = _build_table_identity(tables)
+    result: dict[str, dict[str, str]] = {}
+    for name, tbl in tables.items():
+        resolved: dict[str, str] = {}
+        for fk_col, parent_table in tbl.foreign_keys.items():
+            parent_name = identity.get(id(parent_table))
+            if parent_name is None:
+                raise InvalidRequestError(
+                    f"Table '{name}' references a Table object via '{fk_col}' "
+                    f"that is not in the tables dict.",
+                    param="foreign_keys",
+                )
+            resolved[fk_col] = parent_name
+        result[name] = resolved
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -88,26 +150,13 @@ def _validate_tables(tables: dict[str, Table]) -> None:
     if not tables:
         raise InvalidRequestError("tables must contain at least one table.", param="tables")
 
-    for name, tbl in tables.items():
-        for fk_col, ref_table in tbl.references.items():
-            if ref_table not in tables:
-                raise InvalidRequestError(
-                    f"Table '{name}' references '{ref_table}' via column '{fk_col}', "
-                    f"but '{ref_table}' is not in tables.",
-                    param="references",
-                )
-            if tables[ref_table].primary_key is None:
-                raise InvalidRequestError(
-                    f"Table '{name}' references '{ref_table}', but '{ref_table}' "
-                    f"has no primary_key defined.",
-                    param="primary_key",
-                )
+    _resolve_fk_targets(tables)
 
     order = _topological_sort(tables)
     if order is None:
         raise InvalidRequestError(
-            "Circular dependency detected among table references.",
-            param="references",
+            "Circular dependency detected among table foreign_keys.",
+            param="foreign_keys",
         )
 
 
@@ -117,11 +166,13 @@ def _validate_tables(tables: dict[str, Table]) -> None:
 
 def _topological_sort(tables: dict[str, Table]) -> list[str] | None:
     """Return generation order (parents first) or None if cycle detected."""
+    resolved = _resolve_fk_targets(tables)
+
     in_degree: dict[str, int] = {name: 0 for name in tables}
     dependents: dict[str, list[str]] = {name: [] for name in tables}
 
-    for name, tbl in tables.items():
-        parents = set(tbl.references.values())
+    for name in tables:
+        parents = set(resolved[name].values())
         in_degree[name] = len(parents)
         for parent in parents:
             dependents[parent].append(name)

--- a/dataxid/encoder/_builtin.py
+++ b/dataxid/encoder/_builtin.py
@@ -13,7 +13,13 @@ import pandas as pd
 import torch
 from torch import nn
 
-from dataxid.encoder._nn import Encoder
+from dataxid.encoder._nn import (
+    _DIGIT_ENCODING_THRESHOLD,
+    RIDX_PREFIX,
+    SIDX_PREFIX,
+    SLEN_PREFIX,
+    Encoder,
+)
 from dataxid.encoder._ports import ColumnSchema, ModelCapacity
 from dataxid.exceptions import ModelNotReadyError
 from dataxid.pipeline._analyze import compute_stats, unpack_stats
@@ -29,6 +35,7 @@ class BuiltinEncoder:
 
     def __init__(self) -> None:
         self.schema: ColumnSchema | None = None
+        self.ctx_schema: ColumnSchema | None = None
         self.encoder: nn.Module | None = None
 
     def analyze(
@@ -39,6 +46,8 @@ class BuiltinEncoder:
         model_size: str,
         device: torch.device,
         encoding_types: dict[str, str] | None = None,
+        parent: pd.DataFrame | None = None,
+        parent_encoding_types: dict[str, str] | None = None,
     ) -> None:
         column_stats = compute_stats(
             df, features, value_protection=True,
@@ -56,17 +65,37 @@ class BuiltinEncoder:
             column_stats=column_stats,
         )
 
+        ctx_cardinalities: dict[str, int] | None = None
+        if parent is not None:
+            ctx_features = list(parent.columns)
+            ctx_stats = compute_stats(
+                parent, ctx_features, value_protection=True,
+                encoding_types=parent_encoding_types,
+            )
+            ctx_cards, ctx_enc_map, ctx_val_mappings = unpack_stats(ctx_stats)
+            ctx_cardinalities = ctx_cards
+            self.ctx_schema = ColumnSchema(
+                features=ctx_features,
+                cardinalities=ctx_cards,
+                encoding_map=ctx_enc_map,
+                value_mappings=ctx_val_mappings,
+                column_stats=ctx_stats,
+            )
+
         self.encoder = Encoder(
             cardinalities=cardinalities,
             model_size=ModelCapacity(model_size),
             embedding_dim=embedding_dim,
             device=device,
+            ctx_cardinalities=ctx_cardinalities,
         )
 
         n_params = sum(p.numel() for p in self.encoder.parameters())
+        ctx_info = f", ctx={len(ctx_cardinalities)} sub-cols" if ctx_cardinalities else ""
         logger.info(
-            "Encoder initialized: %d sub-cols → %dd embedding (%s params)",
+            "Encoder initialized: %d sub-cols%s → %dd embedding (%s params)",
             len(cardinalities),
+            ctx_info,
             embedding_dim,
             f"{n_params:,}",
         )
@@ -92,6 +121,29 @@ class BuiltinEncoder:
             probs_map[sub_col] = np.clip(probs, a_min=1e-12, a_max=None)
         return probs_map
 
+    def _compute_ctx_priors(
+        self,
+        ctx_df: pd.DataFrame,
+    ) -> dict[str, np.ndarray]:
+        """Compute empirical priors for context columns."""
+        if self.ctx_schema is None:
+            return {}
+        encoded = encode_columns(
+            ctx_df, self.ctx_schema.features, self.ctx_schema.column_stats
+        )
+        probs_map: dict[str, np.ndarray] = {}
+        for sub_col, cardinality in self.ctx_schema.cardinalities.items():
+            values = encoded[sub_col]
+            counts = np.zeros(cardinality)
+            for idx in values:
+                if 0 <= idx < cardinality:
+                    counts[int(idx)] += 1
+            alpha = _SMOOTHING
+            total = counts.sum() + alpha * cardinality
+            probs = (counts + alpha) / max(total, 1e-12)
+            probs_map[sub_col] = np.clip(probs, a_min=1e-12, a_max=None)
+        return probs_map
+
     def _prepare_tensors(
         self,
         df: pd.DataFrame,
@@ -106,16 +158,106 @@ class BuiltinEncoder:
             for k, v in encoded.items()
         }
 
+    def _prepare_ctx_tensors(
+        self,
+        ctx_df: pd.DataFrame,
+    ) -> dict[str, torch.Tensor]:
+        """Encode context table to tensor dict."""
+        if self.ctx_schema is None:
+            raise ModelNotReadyError("No context schema — analyze with parent first.")
+        encoded = encode_columns(
+            ctx_df, self.ctx_schema.features, self.ctx_schema.column_stats
+        )
+        device = self.encoder.device  # type: ignore[union-attr]
+        return {
+            k: torch.tensor(v, dtype=torch.long).unsqueeze(-1).to(device)
+            for k, v in encoded.items()
+        }
+
+    def _prepare_sequential_tensors(
+        self,
+        df: pd.DataFrame,
+        group_by: str,
+        seq_len_max: int,
+        parent: pd.DataFrame | None = None,
+        parent_key: str | None = None,
+    ) -> dict[str, list]:
+        """Encode sequential data → dict of list-columns (entity × timesteps).
+
+        Parent entities with zero child rows are included as 0-length sequences
+        (single padding row with SLEN=0) so the model learns the "no children" pattern.
+
+        Returns nested lists (not tensors) for SequentialSplitDataLoader compatibility.
+        """
+        self._check_fitted()
+        key = group_by
+
+        def _pad_group(g: pd.DataFrame) -> pd.DataFrame:
+            pad_row = {c: [0] for c in g.columns if c != key}
+            pad_row[key] = [g.iloc[0][key]]
+            return pd.concat([g, pd.DataFrame(pad_row)], ignore_index=True)
+
+        df_padded = (
+            df.groupby(key, sort=False)[df.columns.tolist()]
+            .apply(_pad_group)
+            .reset_index(drop=True)
+        )
+
+        if parent is not None and parent_key:
+            child_keys = set(df[key].unique())
+            all_parent_keys = set(parent[parent_key].unique())
+            missing_keys = all_parent_keys - child_keys
+            if missing_keys:
+                zero_row = {c: 0 for c in df_padded.columns if c != key}
+                zero_rows = [{**zero_row, key: k} for k in missing_keys]
+                df_padded = pd.concat([df_padded, pd.DataFrame(zero_rows)], ignore_index=True)
+
+        sidx = df_padded.groupby(key).cumcount(ascending=True)
+        slen = df_padded.groupby(key)[key].transform("size") - 1
+        ridx = df_padded.groupby(key).cumcount(ascending=False)
+
+        sidx_df = _encode_positional(sidx, seq_len_max, SIDX_PREFIX)
+        slen_df = _encode_positional(slen, seq_len_max, SLEN_PREFIX)
+        ridx_df = _encode_positional(ridx, seq_len_max, RIDX_PREFIX)
+
+        features = self.schema.features  # type: ignore[union-attr]
+        encoded = encode_columns(df_padded[features], features, self.schema.column_stats)
+
+        pos_dfs = pd.concat([sidx_df, slen_df, ridx_df], axis=1)
+        all_encoded = pd.concat(
+            [df_padded[[key]], pos_dfs, pd.DataFrame(encoded)], axis=1,
+        )
+
+        data_cols = [c for c in all_encoded.columns if c != key]
+        grouped = all_encoded.groupby(key, sort=False)
+
+        result: dict[str, list] = {}
+        for col in data_cols:
+            result[col] = grouped[col].apply(list).tolist()
+
+        if parent is not None and self.ctx_schema is not None and parent_key:
+            entity_keys = list(grouped.groups.keys())
+            ctx_aligned = parent.set_index(parent_key).loc[entity_keys].reset_index(drop=True)
+            ctx_encoded = encode_columns(
+                ctx_aligned, self.ctx_schema.features, self.ctx_schema.column_stats,
+            )
+            for k_ctx, v_ctx in ctx_encoded.items():
+                result[k_ctx] = v_ctx.tolist() if hasattr(v_ctx, "tolist") else list(v_ctx)
+
+        return result
+
     def _encode_batch(
         self,
         batch: dict[str, torch.Tensor],
+        ctx: dict[str, torch.Tensor] | None = None,
     ) -> torch.Tensor:
         self._check_fitted()
-        return self.encoder(batch)  # type: ignore[misc]
+        return self.encoder(batch, ctx=ctx)  # type: ignore[misc]
 
     def encode(
         self,
         df: pd.DataFrame,
+        ctx_df: pd.DataFrame | None = None,
     ) -> torch.Tensor:
         self._check_fitted()
         encoded = encode_columns(
@@ -126,7 +268,26 @@ class BuiltinEncoder:
             k: torch.tensor(v, dtype=torch.long).unsqueeze(-1).to(device)
             for k, v in encoded.items()
         }
-        return self.encoder(x)  # type: ignore[misc]
+        ctx_tensors = None
+        if ctx_df is not None and self.ctx_schema is not None:
+            ctx_encoded = encode_columns(
+                ctx_df, self.ctx_schema.features, self.ctx_schema.column_stats
+            )
+            ctx_tensors = {
+                k: torch.tensor(v, dtype=torch.long).unsqueeze(-1).to(device)
+                for k, v in ctx_encoded.items()
+            }
+        return self.encoder(x, ctx=ctx_tensors)  # type: ignore[misc]
+
+    def encode_context_only(self, ctx_df: pd.DataFrame) -> torch.Tensor:
+        """Encode context table through FeatureCompressor only (no target encoder)."""
+        self._check_fitted()
+        ctx_tensors = self._prepare_ctx_tensors(ctx_df)
+        ctx_embeds = self.encoder.ctx_compressor(ctx_tensors)  # type: ignore[union-attr]
+        if ctx_embeds:
+            return ctx_embeds[0]
+        device = self.encoder.device  # type: ignore[union-attr]
+        return torch.zeros(len(ctx_df), 0, device=device)
 
     def parameters(self):
         self._check_fitted()
@@ -134,16 +295,36 @@ class BuiltinEncoder:
 
     def _vocab_sizes(self) -> dict[str, int]:
         self._check_fitted()
-        return dict(self.schema.cardinalities)  # type: ignore[union-attr]
+        combined = dict(self.schema.cardinalities)  # type: ignore[union-attr]
+        if self.ctx_schema is not None:
+            combined.update(self.ctx_schema.cardinalities)
+        return combined
 
     def _column_stats(self) -> dict[str, dict]:
         self._check_fitted()
-        return dict(self.schema.column_stats)  # type: ignore[union-attr]
+        combined = dict(self.schema.column_stats)  # type: ignore[union-attr]
+        if self.ctx_schema is not None:
+            combined.update(self.ctx_schema.column_stats)
+        return combined
 
     def _value_mappings(self) -> dict[str, dict]:
         self._check_fitted()
-        return dict(self.schema.value_mappings)  # type: ignore[union-attr]
+        combined = dict(self.schema.value_mappings)  # type: ignore[union-attr]
+        if self.ctx_schema is not None:
+            combined.update(self.ctx_schema.value_mappings)
+        return combined
 
     def _check_fitted(self) -> None:
         if self.schema is None or self.encoder is None:
             raise ModelNotReadyError("Call analyze() first.")
+
+
+def _encode_positional(vals: pd.Series, max_seq_len: int, prefix: str) -> pd.DataFrame:
+    """Encode positional values (SIDX/SLEN/RIDX) to sub-column DataFrame."""
+    if max_seq_len < _DIGIT_ENCODING_THRESHOLD:
+        return pd.DataFrame({f"{prefix}cat": vals.values})
+    n_digits = len(str(max_seq_len))
+    rows = vals.astype(str).str.pad(width=n_digits, fillchar="0").apply(list).tolist()
+    df = pd.DataFrame(rows).astype(int)
+    df.columns = [f"{prefix}E{i}" for i in range(n_digits - 1, -1, -1)]
+    return df

--- a/dataxid/encoder/_nn.py
+++ b/dataxid/encoder/_nn.py
@@ -22,10 +22,32 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 POSITIONAL_COLUMN = "__pos__"
+SIDX_PREFIX = f"{POSITIONAL_COLUMN}{WIRE_SUB_COLUMN_SEP}sidx_"
 RIDX_PREFIX = f"{POSITIONAL_COLUMN}{WIRE_SUB_COLUMN_SEP}ridx_"
 SLEN_PREFIX = f"{POSITIONAL_COLUMN}{WIRE_SUB_COLUMN_SEP}slen_"
 
+_DIGIT_ENCODING_THRESHOLD = 100
+
 ModelCapacityOrUnits = ModelCapacity | dict[str, list[int]]
+
+
+def get_positional_cardinalities(seq_len_max: int) -> dict[str, int]:
+    """Positional sub-column cardinalities for sequential mode (SIDX, SLEN, RIDX)."""
+    if seq_len_max < _DIGIT_ENCODING_THRESHOLD:
+        return {
+            f"{SIDX_PREFIX}cat": seq_len_max + 1,
+            f"{SLEN_PREFIX}cat": seq_len_max + 1,
+            f"{RIDX_PREFIX}cat": seq_len_max + 1,
+        }
+    digits = [int(d) for d in str(seq_len_max)]
+    cards: dict[str, int] = {}
+    for i, digit in enumerate(digits):
+        e_idx = len(digits) - 1 - i
+        card = (digit + 1) if i == 0 else 10
+        cards[f"{SIDX_PREFIX}E{e_idx}"] = card
+        cards[f"{RIDX_PREFIX}E{e_idx}"] = card
+        cards[f"{SLEN_PREFIX}E{e_idx}"] = card
+    return cards
 
 _DROPOUT_RATE = 0.25
 

--- a/dataxid/encoder/_ports.py
+++ b/dataxid/encoder/_ports.py
@@ -90,6 +90,8 @@ class EncoderPort(Protocol):
         model_size: str,
         device: torch.device,
         encoding_types: dict[str, str] | None = None,
+        parent: pd.DataFrame | None = None,
+        parent_encoding_types: dict[str, str] | None = None,
     ) -> None:
         """Analyze raw data → populate schema and build encoder network."""
         ...

--- a/dataxid/encoder/_wrapper.py
+++ b/dataxid/encoder/_wrapper.py
@@ -56,27 +56,74 @@ class Encoder:
         self._backend: EncoderPort | None = None
         self._optimizer: torch.optim.Optimizer | None = None
         self._tensors: dict[str, torch.Tensor] | None = None
+        self._ctx_tensors: dict[str, torch.Tensor] | None = None
         self._live_embeddings: dict[int, torch.Tensor] = {}
         self._embed_counter: int = 0
         self.column_stats: dict[str, dict] = {}
+        self.ctx_column_stats: dict[str, dict] = {}
         self.features: list[str] = []
+        self.ctx_features: list[str] = []
+        self.has_context: bool = False
+        self.is_sequential: bool = False
+        self.seq_len_max: int = 1
+        self.seq_len_median: int = 1
+        self._group_by: str | None = None
+        self._parent_key: str | None = None
+        self._seq_data: dict[str, list] | None = None
 
     def analyze(
         self,
         df: pd.DataFrame,
         encoding_types: dict[str, str] | None = None,
+        parent: pd.DataFrame | None = None,
+        parent_encoding_types: dict[str, str] | None = None,
+        group_by: str | None = None,
+        parent_key: str | None = None,
     ) -> dict[str, Any]:
-        """Analyze raw data and return metadata for model creation."""
-        features = list(df.columns)
+        """Analyze raw data (and optional parent table) → return metadata for model creation.
+
+        When parent is provided, parent columns are analyzed and compressed
+        via FeatureCompressor inside the same encoder — producing a combined embedding.
+
+        When group_by is provided and rows are grouped (1:N), sequential mode
+        is detected automatically: seq_len_max/median computed, positional cardinalities added.
+        """
+        from dataxid.encoder._nn import get_positional_cardinalities
+
+        self._group_by = group_by
+
+        exclude_cols: set[str] = set()
+        if group_by:
+            exclude_cols.add(group_by)
+        features = [c for c in df.columns if c not in exclude_cols]
+        self.features = features
+
+        if parent is not None:
+            ctx_exclude: set[str] = set()
+            if parent_key:
+                ctx_exclude.add(parent_key)
+            if group_by and group_by in parent.columns:
+                ctx_exclude.add(group_by)
+            self.ctx_features = [c for c in parent.columns if c not in ctx_exclude]
+            self.has_context = True
+
+        if group_by and group_by in df.columns:
+            seq_lens = df.groupby(group_by).size()
+            self.is_sequential = True
+            self.seq_len_max = int(seq_lens.max())
+            self.seq_len_median = int(seq_lens.median())
 
         self._backend = _create_backend()
+        ctx_for_analyze = parent[self.ctx_features] if parent is not None else None
         self._backend.analyze(
-            df=df,
+            df=df[features],
             features=features,
             embedding_dim=self._embedding_dim,
             model_size=self._model_size,
             device=torch.device(self._device),
             encoding_types=encoding_types,
+            parent=ctx_for_analyze,
+            parent_encoding_types=parent_encoding_types,
         )
 
         self._optimizer = torch.optim.AdamW(
@@ -84,25 +131,71 @@ class Encoder:
             lr=_DEFAULT_LR,
         )
 
-        empirical_probs = self._backend._compute_priors(df)
-
-        self.features = features
         self.column_stats = self._backend._column_stats()
 
+        cardinalities = self._backend._vocab_sizes()
+        empirical_probs = self._backend._compute_priors(df[features])
+        all_empirical_probs = {k: v.tolist() for k, v in empirical_probs.items()}
+        all_value_mappings = self._backend._value_mappings()
+
+        if parent is not None:
+            ctx_probs = self._backend._compute_ctx_priors(ctx_for_analyze)
+            all_empirical_probs.update({k: v.tolist() for k, v in ctx_probs.items()})
+            self.ctx_column_stats = {
+                k: v for k, v in self.column_stats.items()
+                if k in self.ctx_features
+            }
+
+        if self.has_context and self._backend.ctx_schema is not None:
+            ctx_sub_cols = set(self._backend.ctx_schema.cardinalities.keys())
+            cardinalities = {k: v for k, v in cardinalities.items() if k not in ctx_sub_cols}
+            all_empirical_probs = {k: v for k, v in all_empirical_probs.items() if k not in ctx_sub_cols}
+            all_value_mappings = {k: v for k, v in all_value_mappings.items() if k not in ctx_sub_cols}
+
+        if self.is_sequential:
+            pos_cards = get_positional_cardinalities(self.seq_len_max)
+            cardinalities = {**pos_cards, **cardinalities}
+            for sc, card in pos_cards.items():
+                all_empirical_probs[sc] = [1.0 / card] * card
+
         return _sanitize_null_bytes({
-            "cardinalities": self._backend._vocab_sizes(),
+            "cardinalities": cardinalities,
             "features": features,
             "column_stats": self.column_stats,
-            "value_mappings": self._backend._value_mappings(),
-            "empirical_probs": {
-                k: v.tolist() for k, v in empirical_probs.items()
-            },
+            "value_mappings": all_value_mappings,
+            "empirical_probs": all_empirical_probs,
+            "has_context": self.has_context,
+            "is_sequential": self.is_sequential,
+            "seq_len_max": self.seq_len_max,
+            "seq_len_median": self.seq_len_median,
         })
 
-    def prepare(self, df: pd.DataFrame) -> None:
+    def prepare(
+        self,
+        df: pd.DataFrame,
+        parent: pd.DataFrame | None = None,
+        parent_key: str | None = None,
+    ) -> None:
         """Pre-encode data to tensors. Call once, reuse across epochs."""
         self._check_ready()
-        self._tensors = self._backend._prepare_tensors(df)
+        self._parent_key = parent_key
+
+        if self.is_sequential and self._group_by:
+            self._seq_data = self._backend._prepare_sequential_tensors(
+                df,
+                group_by=self._group_by,
+                seq_len_max=self.seq_len_max,
+                parent=parent,
+                parent_key=parent_key,
+            )
+            self._seq_ctx_embeddings = self._precompute_seq_ctx_embeddings(
+                df, parent, parent_key,
+            )
+            return
+
+        self._tensors = self._backend._prepare_tensors(df[self.features])
+        if parent is not None and self.has_context:
+            self._ctx_tensors = self._backend._prepare_ctx_tensors(parent)
 
     def encode_batch(
         self,
@@ -128,7 +221,14 @@ class Encoder:
         else:
             batch = self._tensors
 
-        embedding = self._backend._encode_batch(batch)
+        ctx_batch = None
+        if self._ctx_tensors is not None:
+            if indices is not None:
+                ctx_batch = {k: v[indices] for k, v in self._ctx_tensors.items()}
+            else:
+                ctx_batch = self._ctx_tensors
+
+        embedding = self._backend._encode_batch(batch, ctx=ctx_batch)
 
         if add_noise and self._privacy_enabled:
             embedding = self._add_noise(embedding)
@@ -196,6 +296,10 @@ class Encoder:
     ) -> list[dict[str, Any]]:
         """Encode all data into batches (frozen encoder mode)."""
         self._check_ready()
+
+        if self.is_sequential:
+            return self._encode_batches_sequential(batch_size, val_split)
+
         if self._tensors is None:
             raise RuntimeError("Call prepare(df) before _encode_batches()")
 
@@ -228,21 +332,123 @@ class Encoder:
 
         return batches
 
+    @torch.no_grad()
+    def _precompute_seq_ctx_embeddings(
+        self,
+        df: pd.DataFrame,
+        parent: pd.DataFrame | None,
+        parent_key: str | None,
+    ) -> torch.Tensor:
+        """Pre-compute frozen context embeddings aligned with entity order in _seq_data."""
+        first_key = next(iter(self._seq_data))
+        n_entities = len(self._seq_data[first_key])
+        compressor = self._backend.encoder.ctx_compressor
+        ctx_dim = compressor.dim_output if compressor is not None else 0
+
+        if parent is None or compressor is None or not self.ctx_features:
+            return torch.zeros(n_entities, ctx_dim, device=torch.device(self._device))
+
+        child_keys = list(df.groupby(self._group_by, sort=False).groups.keys())
+        if parent_key:
+            all_parent_keys = list(parent[parent_key].unique())
+            child_set = set(child_keys)
+            missing_keys = [k for k in all_parent_keys if k not in child_set]
+            entity_keys = child_keys + missing_keys
+            ctx_aligned = (
+                parent.set_index(parent_key).loc[entity_keys].reset_index(drop=True)
+            )
+        else:
+            ctx_aligned = parent.head(n_entities).reset_index(drop=True)
+
+        ctx_clean = ctx_aligned[self.ctx_features]
+        return self._backend.encode_context_only(ctx_clean)
+
+    def _encode_batches_sequential(
+        self,
+        batch_size: int = 256,
+        val_split: float = 0.1,
+    ) -> list[dict[str, Any]]:
+        """Encode sequential data into batches. No target encoder — context-only embedding."""
+        if self._seq_data is None:
+            raise RuntimeError("Call prepare(df) before _encode_batches()")
+
+        first_key = next(iter(self._seq_data))
+        n_entities = len(self._seq_data[first_key])
+        val_size = max(1, round(n_entities * val_split))
+        train_size = n_entities - val_size
+
+        all_indices = list(range(n_entities))
+        random.shuffle(all_indices)
+        train_indices = all_indices[:train_size]
+        val_indices = all_indices[train_size:]
+
+        ctx_sub_cols = set(self._backend.ctx_schema.cardinalities.keys()) if self._backend.ctx_schema else set()
+        seq_keys = [k for k in self._seq_data if k not in ctx_sub_cols]
+
+        def _make_batch(indices: list[int]) -> dict[str, Any]:
+            targets: dict[str, list] = {}
+            for k in seq_keys:
+                targets[k] = [self._seq_data[k][i] for i in indices]
+
+            embedding = self._seq_ctx_embeddings[indices]
+            return {
+                "embedding": serialize_embedding(embedding),
+                "targets": targets,
+                "is_sequential": True,
+            }
+
+        batches: list[dict[str, Any]] = []
+        n_train_batches = math.ceil(train_size / batch_size)
+        for i in range(n_train_batches):
+            start = i * batch_size
+            end = min(start + batch_size, train_size)
+            idx = train_indices[start:end]
+            batch = _make_batch(idx)
+            batch["is_validation"] = False
+            batches.append(batch)
+
+        val_batch = _make_batch(val_indices)
+        val_batch["is_validation"] = True
+        batches.append(val_batch)
+
+        return batches
+
     def _generation_embedding(
         self,
         n_samples: int,
         seed_data: pd.DataFrame | None = None,
+        parent: pd.DataFrame | None = None,
     ) -> dict[str, Any]:
-        """Produce embedding for generation. Zero embedding if no seed_data."""
+        """Produce embedding for generation.
+
+        Sequential mode: context-only embedding via FeatureCompressor.
+        Flat mode: full embedding (target + context) or zero embedding.
+        """
         self._check_ready()
 
+        if self.is_sequential:
+            if parent is not None and self.has_context:
+                ctx_features_only = parent[self.ctx_features] if self.ctx_features else parent
+                embedding = self._backend.encode_context_only(ctx_features_only)
+            else:
+                ctx_dim = self._backend.encoder.ctx_compressor.dim_output if (  # type: ignore[union-attr]
+                    self._backend.encoder.ctx_compressor is not None  # type: ignore[union-attr]
+                ) else 0
+                n_entities = n_samples
+                embedding = torch.zeros(
+                    n_entities, ctx_dim, device=torch.device(self._device),
+                )
+            return serialize_embedding(embedding)
+
         if seed_data is not None:
-            embedding = self._backend.encode(seed_data)
+            ctx_clean = parent[self.ctx_features] if (parent is not None and self.ctx_features) else parent
+            embedding = self._backend.encode(seed_data, ctx_df=ctx_clean)
             if self._privacy_enabled:
                 embedding = self._add_noise(embedding)
         else:
+            embed_dim = self._embedding_dim
             embedding = torch.zeros(
-                n_samples, self._embedding_dim, device=torch.device(self._device),
+                n_samples, embed_dim, device=torch.device(self._device),
             )
 
         return serialize_embedding(embedding)

--- a/dataxid/encoder/_wrapper.py
+++ b/dataxid/encoder/_wrapper.py
@@ -67,7 +67,7 @@ class Encoder:
         self.is_sequential: bool = False
         self.seq_len_max: int = 1
         self.seq_len_median: int = 1
-        self._group_by: str | None = None
+        self._foreign_key: str | None = None
         self._parent_key: str | None = None
         self._seq_data: dict[str, list] | None = None
 
@@ -77,7 +77,7 @@ class Encoder:
         encoding_types: dict[str, str] | None = None,
         parent: pd.DataFrame | None = None,
         parent_encoding_types: dict[str, str] | None = None,
-        group_by: str | None = None,
+        foreign_key: str | None = None,
         parent_key: str | None = None,
     ) -> dict[str, Any]:
         """Analyze raw data (and optional parent table) → return metadata for model creation.
@@ -85,16 +85,16 @@ class Encoder:
         When parent is provided, parent columns are analyzed and compressed
         via FeatureCompressor inside the same encoder — producing a combined embedding.
 
-        When group_by is provided and rows are grouped (1:N), sequential mode
+        When foreign_key is provided and rows are grouped (1:N), sequential mode
         is detected automatically: seq_len_max/median computed, positional cardinalities added.
         """
         from dataxid.encoder._nn import get_positional_cardinalities
 
-        self._group_by = group_by
+        self._foreign_key = foreign_key
 
         exclude_cols: set[str] = set()
-        if group_by:
-            exclude_cols.add(group_by)
+        if foreign_key:
+            exclude_cols.add(foreign_key)
         features = [c for c in df.columns if c not in exclude_cols]
         self.features = features
 
@@ -102,13 +102,13 @@ class Encoder:
             ctx_exclude: set[str] = set()
             if parent_key:
                 ctx_exclude.add(parent_key)
-            if group_by and group_by in parent.columns:
-                ctx_exclude.add(group_by)
+            if foreign_key and foreign_key in parent.columns:
+                ctx_exclude.add(foreign_key)
             self.ctx_features = [c for c in parent.columns if c not in ctx_exclude]
             self.has_context = True
 
-        if group_by and group_by in df.columns:
-            seq_lens = df.groupby(group_by).size()
+        if foreign_key and foreign_key in df.columns:
+            seq_lens = df.groupby(foreign_key).size()
             self.is_sequential = True
             self.seq_len_max = int(seq_lens.max())
             self.seq_len_median = int(seq_lens.median())
@@ -180,10 +180,10 @@ class Encoder:
         self._check_ready()
         self._parent_key = parent_key
 
-        if self.is_sequential and self._group_by:
+        if self.is_sequential and self._foreign_key:
             self._seq_data = self._backend._prepare_sequential_tensors(
                 df,
-                group_by=self._group_by,
+                group_by=self._foreign_key,
                 seq_len_max=self.seq_len_max,
                 parent=parent,
                 parent_key=parent_key,
@@ -348,7 +348,7 @@ class Encoder:
         if parent is None or compressor is None or not self.ctx_features:
             return torch.zeros(n_entities, ctx_dim, device=torch.device(self._device))
 
-        child_keys = list(df.groupby(self._group_by, sort=False).groups.keys())
+        child_keys = list(df.groupby(self._foreign_key, sort=False).groups.keys())
         if parent_key:
             all_parent_keys = list(parent[parent_key].unique())
             child_set = set(child_keys)

--- a/dataxid/pipeline/_analyze.py
+++ b/dataxid/pipeline/_analyze.py
@@ -439,6 +439,24 @@ _LATLONG_PATTERNS = re.compile(
     re.IGNORECASE,
 )
 
+_DATETIME_NAME_PATTERNS = re.compile(
+    r"(date|time|timestamp|datetime|created|updated|_at$|_dt$|_ts$)",
+    re.IGNORECASE,
+)
+
+_DATETIME_PARSE_THRESHOLD = 0.8
+
+
+def _looks_like_datetime(series: pd.Series, column_name: str) -> bool:
+    """Heuristic: does a string column likely contain datetime values?"""
+    if _DATETIME_NAME_PATTERNS.search(column_name):
+        sample = series.dropna().head(200)
+        if len(sample) == 0:
+            return False
+        parsed = pd.to_datetime(sample, errors="coerce", format="mixed")
+        return parsed.notna().mean() >= _DATETIME_PARSE_THRESHOLD
+    return False
+
 
 def detect_encoding(series: pd.Series, column_name: str = "") -> EncodingType:
     """Infer the best encoding type from data characteristics and column semantics."""
@@ -460,6 +478,8 @@ def detect_encoding(series: pd.Series, column_name: str = "") -> EncodingType:
             return EncodingType.numeric_binned
 
     if series.dtype == object:
+        if _looks_like_datetime(series, column_name):
+            return EncodingType.datetime
         sample = series.dropna().head(100)
         if len(sample) > 0:
             avg_len = sample.astype(str).str.len().mean()

--- a/dataxid/training/_model.py
+++ b/dataxid/training/_model.py
@@ -28,11 +28,25 @@ logger = logging.getLogger(__name__)
 # Input validation
 # ---------------------------------------------------------------------------
 
+def _infer_parent_key(
+    foreign_key: str,
+    parent: pd.DataFrame,
+) -> str:
+    """Infer parent_key from foreign_key if the column exists in parent."""
+    if foreign_key in parent.columns:
+        return foreign_key
+    raise InvalidRequestError(
+        f"parent_key not provided and column '{foreign_key}' not found in parent. "
+        f"Specify parent_key explicitly when FK and PK column names differ.",
+        param="parent_key",
+    )
+
+
 def _validate_context_params(
     data: pd.DataFrame,
     parent: pd.DataFrame | None,
     parent_encoding_types: dict[str, str] | None,
-    group_by: str | None,
+    foreign_key: str | None,
     parent_key: str | None,
 ) -> None:
     if parent_encoding_types is not None and parent is None:
@@ -47,10 +61,10 @@ def _validate_context_params(
             param="parent_key",
         )
 
-    if group_by is not None and group_by not in data.columns:
+    if foreign_key is not None and foreign_key not in data.columns:
         raise InvalidRequestError(
-            f"Column '{group_by}' not found in data.",
-            param="group_by",
+            f"Column '{foreign_key}' not found in data.",
+            param="foreign_key",
         )
 
     if (
@@ -63,12 +77,12 @@ def _validate_context_params(
             param="parent_key",
         )
 
-    if parent is not None and group_by is None:
+    if parent is not None and foreign_key is None:
         if len(parent) != len(data):
             raise InvalidRequestError(
                 f"Row count mismatch: parent has {len(parent)} rows, "
                 f"data has {len(data)}. In flat context mode rows must be "
-                f"aligned 1:1. For 1:N joins use group_by.",
+                f"aligned 1:1. For 1:N joins use foreign_key.",
                 param="parent",
             )
 
@@ -109,7 +123,7 @@ class Model:
         base_url: str | None = None,
         parent: pd.DataFrame | None = None,
         parent_encoding_types: dict[str, str] | None = None,
-        group_by: str | None = None,
+        foreign_key: str | None = None,
         parent_key: str | None = None,
     ) -> Model:
         """
@@ -123,15 +137,19 @@ class Model:
             base_url: Override dataxid.base_url
             parent: Parent table for context-aware generation
             parent_encoding_types: Encoding overrides for parent columns
-            group_by: Column in data linking rows to parent entities (enables sequential mode)
-            parent_key: Primary key column in parent table
+            foreign_key: FK column in data linking rows to parent (enables sequential mode)
+            parent_key: PK column in parent table (inferred from foreign_key if same name)
 
         Returns:
             Trained Model ready for generate()
         """
         config = _resolve_config(config)
+
+        if parent is not None and foreign_key is not None and parent_key is None:
+            parent_key = _infer_parent_key(foreign_key, parent)
+
         _validate_context_params(
-            data, parent, parent_encoding_types, group_by, parent_key,
+            data, parent, parent_encoding_types, foreign_key, parent_key,
         )
         http = DataxidClient(api_key=api_key, base_url=base_url)
 
@@ -158,14 +176,14 @@ class Model:
             encoding_types=encoding_types,
             parent=parent,
             parent_encoding_types=parent_encoding_types,
-            group_by=group_by,
+            foreign_key=foreign_key,
             parent_key=parent_key,
         )
 
         if encoder.is_sequential and parent is None:
             raise InvalidRequestError(
                 "Sequential mode requires parent. Groups in "
-                "group_by have multiple rows, which triggers "
+                "foreign_key have multiple rows, which triggers "
                 "entity-level training.",
                 param="parent",
             )
@@ -257,12 +275,12 @@ class Model:
         features = self._encoder.features
         df = decode_columns(raw_codes, features, column_stats)
 
-        group_by = self._encoder._group_by
-        if group_by and ctx is not None and self._encoder._parent_key:
+        fk_col = self._encoder._foreign_key
+        if fk_col and ctx is not None and self._encoder._parent_key:
             pk_col = self._encoder._parent_key
             if pk_col in ctx.columns:
                 key_values = ctx[pk_col].values
-                df.insert(0, group_by, [
+                df.insert(0, fk_col, [
                     key_values[i] if i < len(key_values) else i
                     for i in range(len(df))
                 ])
@@ -343,19 +361,19 @@ class Model:
         features = self._encoder.features
         df = decode_columns(df_flat.to_dict(orient="list"), features, column_stats)
 
-        group_by = self._encoder._group_by
-        if group_by:
+        fk_col = self._encoder._foreign_key
+        if fk_col:
             if (parent is not None
                     and self._encoder._parent_key
                     and self._encoder._parent_key in parent.columns):
                 key_values = parent[self._encoder._parent_key].values
-                df[group_by] = [
+                df[fk_col] = [
                     key_values[idx] if idx < len(key_values) else idx
                     for idx in entity_indices
                 ]
             else:
-                df[group_by] = entity_indices
-            cols = [group_by] + [c for c in df.columns if c != group_by]
+                df[fk_col] = entity_indices
+            cols = [fk_col] + [c for c in df.columns if c != fk_col]
             df = df[cols]
 
         self.status = "ready"

--- a/dataxid/training/_model.py
+++ b/dataxid/training/_model.py
@@ -16,11 +16,62 @@ import torch
 
 from dataxid.client._http import DataxidClient
 from dataxid.encoder._wrapper import Encoder
+from dataxid.exceptions import InvalidRequestError
 from dataxid.pipeline._decode import compute_fixed_probs, decode_columns
 from dataxid.training._config import ModelConfig, _resolve_config
 from dataxid.training._frozen import train_frozen
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+def _validate_context_params(
+    data: pd.DataFrame,
+    parent: pd.DataFrame | None,
+    parent_encoding_types: dict[str, str] | None,
+    group_by: str | None,
+    parent_key: str | None,
+) -> None:
+    if parent_encoding_types is not None and parent is None:
+        raise InvalidRequestError(
+            "parent_encoding_types was provided without parent.",
+            param="parent_encoding_types",
+        )
+
+    if parent_key is not None and parent is None:
+        raise InvalidRequestError(
+            "parent_key was provided without parent.",
+            param="parent_key",
+        )
+
+    if group_by is not None and group_by not in data.columns:
+        raise InvalidRequestError(
+            f"Column '{group_by}' not found in data.",
+            param="group_by",
+        )
+
+    if (
+        parent_key is not None
+        and parent is not None
+        and parent_key not in parent.columns
+    ):
+        raise InvalidRequestError(
+            f"Column '{parent_key}' not found in parent.",
+            param="parent_key",
+        )
+
+    if parent is not None and group_by is None:
+        if len(parent) != len(data):
+            raise InvalidRequestError(
+                f"Row count mismatch: parent has {len(parent)} rows, "
+                f"data has {len(data)}. In flat context mode rows must be "
+                f"aligned 1:1. For 1:N joins use group_by.",
+                param="parent",
+            )
+
 
 class Model:
     """A Dataxid model. Trains on your data locally, generates synthetic data via API."""
@@ -32,12 +83,14 @@ class Model:
         encoder: Encoder,
         data: pd.DataFrame,
         config: dict[str, Any],
+        parent: pd.DataFrame | None = None,
     ):
         self.id = model_id
         self.status: str = "training"
         self._client = client
         self._encoder = encoder
         self._data = data
+        self._parent = parent
         self._config = config
         self._n_samples: int | None = None
         self.train_losses: list[float] = []
@@ -54,6 +107,10 @@ class Model:
         config: dict[str, Any] | ModelConfig | None = None,
         api_key: str | None = None,
         base_url: str | None = None,
+        parent: pd.DataFrame | None = None,
+        parent_encoding_types: dict[str, str] | None = None,
+        group_by: str | None = None,
+        parent_key: str | None = None,
     ) -> Model:
         """
         Create a model: analyze data locally, register via API, and train.
@@ -64,11 +121,18 @@ class Model:
             config: Training config — ModelConfig instance or plain dict
             api_key: Override dataxid.api_key
             base_url: Override dataxid.base_url
+            parent: Parent table for context-aware generation
+            parent_encoding_types: Encoding overrides for parent columns
+            group_by: Column in data linking rows to parent entities (enables sequential mode)
+            parent_key: Primary key column in parent table
 
         Returns:
             Trained Model ready for generate()
         """
         config = _resolve_config(config)
+        _validate_context_params(
+            data, parent, parent_encoding_types, group_by, parent_key,
+        )
         http = DataxidClient(api_key=api_key, base_url=base_url)
 
         embedding_dim = config["embedding_dim"]
@@ -89,15 +153,35 @@ class Model:
             privacy_enabled=privacy_enabled,
             privacy_noise=privacy_noise,
         )
-        metadata = encoder.analyze(data, encoding_types=encoding_types)
-        encoder.prepare(data)
+        metadata = encoder.analyze(
+            data,
+            encoding_types=encoding_types,
+            parent=parent,
+            parent_encoding_types=parent_encoding_types,
+            group_by=group_by,
+            parent_key=parent_key,
+        )
+
+        if encoder.is_sequential and parent is None:
+            raise InvalidRequestError(
+                "Sequential mode requires parent. Groups in "
+                "group_by have multiple rows, which triggers "
+                "entity-level training.",
+                param="parent",
+            )
+
+        encoder.prepare(data, parent=parent, parent_key=parent_key)
 
         # --- 2. Register model on API ---
+        effective_embedding_dim = embedding_dim
+        if encoder.is_sequential and encoder._backend.encoder.ctx_compressor is not None:
+            effective_embedding_dim = encoder._backend.encoder.ctx_compressor.dim_output
+
         logger.info("Creating model on API...")
         resp = http.post("/v1/models", json={
             "metadata": metadata,
             "config": {
-                "embedding_dim": embedding_dim,
+                "embedding_dim": effective_embedding_dim,
                 "model_size": model_size,
                 "batch_size": batch_size,
                 "max_epochs": max_epochs,
@@ -112,6 +196,7 @@ class Model:
             encoder=encoder,
             data=data,
             config=config,
+            parent=parent,
         )
         model._n_samples = n_samples
 
@@ -130,22 +215,33 @@ class Model:
         self,
         n_samples: int | None = None,
         seed_data: pd.DataFrame | None = None,
+        parent: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
         """
         Generate synthetic data from the trained model.
 
+        Flat mode: generates n_samples independent rows.
+        Sequential mode: generates variable-length sequences per entity,
+        then flattens to a single DataFrame with entity key column.
+
         Args:
-            n_samples: Number of rows. Defaults to len(training_data).
-            seed_data: DataFrame for conditional generation (optional).
+            n_samples: Flat: number of rows. Sequential: number of entities.
+                       Defaults to len(training_data) or n_entities from training.
+            seed_data: DataFrame for conditional generation (flat only).
+            parent: Parent table for generation. Falls back to training parent.
 
         Returns:
             DataFrame with synthetic data
         """
-        n = n_samples or getattr(self, "_n_samples", None) or len(self._data)
+        ctx = parent if parent is not None else self._parent
 
+        if self._encoder.is_sequential:
+            return self._generate_sequential(n_samples=n_samples, parent=ctx)
+
+        n = n_samples or getattr(self, "_n_samples", None) or len(self._data)
         logger.info("Generating %d synthetic rows...", n)
         embedding = self._encoder._generation_embedding(
-            n_samples=n, seed_data=seed_data,
+            n_samples=n, seed_data=seed_data, parent=ctx,
         )
 
         column_stats = self._encoder.column_stats
@@ -160,9 +256,110 @@ class Model:
         raw_codes = resp["data"]["codes"]
         features = self._encoder.features
         df = decode_columns(raw_codes, features, column_stats)
-        self.status = "ready"
 
+        group_by = self._encoder._group_by
+        if group_by and ctx is not None and self._encoder._parent_key:
+            pk_col = self._encoder._parent_key
+            if pk_col in ctx.columns:
+                key_values = ctx[pk_col].values
+                df.insert(0, group_by, [
+                    key_values[i] if i < len(key_values) else i
+                    for i in range(len(df))
+                ])
+
+        self.status = "ready"
         logger.info("Generated %d rows, %d columns", len(df), len(df.columns))
+        return df
+
+    def _generate_sequential(
+        self,
+        n_samples: int | None = None,
+        parent: pd.DataFrame | None = None,
+    ) -> pd.DataFrame:
+        """Sequential generation: context embedding → autoregressive decode → flatten."""
+        from dataxid.encoder._nn import RIDX_PREFIX, SIDX_PREFIX, SLEN_PREFIX
+
+        if parent is not None and self._encoder.has_context:
+            n_entities = len(parent)
+        else:
+            n_entities = n_samples or getattr(self, "_n_samples", None) or 100
+
+        logger.info("Generating sequences for %d entities (max_len=%d)...",
+                     n_entities, self._encoder.seq_len_max)
+
+        embedding = self._encoder._generation_embedding(
+            n_samples=n_entities, parent=parent,
+        )
+
+        column_stats = self._encoder.column_stats
+        fixed_probs = compute_fixed_probs(column_stats) if column_stats else None
+
+        payload: dict[str, Any] = {
+            "embedding": embedding,
+            "is_sequential": True,
+            "seq_len_max": self._encoder.seq_len_max,
+        }
+        if fixed_probs:
+            payload["fixed_probs"] = fixed_probs
+
+        resp = self._client.post(f"/v1/models/{self.id}/generate", json=payload)
+        raw_codes = resp["data"]["codes"]
+
+        pos_prefixes = (SIDX_PREFIX, SLEN_PREFIX, RIDX_PREFIX)
+        ridx_cols = [k for k in raw_codes if k.startswith(RIDX_PREFIX)]
+
+        if ridx_cols:
+            ridx_lists = raw_codes[ridx_cols[0]]
+            seq_lens = []
+            for entity_ridx in ridx_lists:
+                if entity_ridx[0] == 0:
+                    seq_lens.append(0)
+                    continue
+                length = len(entity_ridx)
+                for t in range(1, len(entity_ridx)):
+                    if entity_ridx[t] == 0:
+                        length = t
+                        break
+                seq_lens.append(length)
+        else:
+            first_key = next(iter(raw_codes))
+            seq_lens = [len(raw_codes[first_key][i]) for i in range(n_entities)]
+
+        data_cols = {k: v for k, v in raw_codes.items()
+                     if not k.startswith(pos_prefixes)}
+
+        rows: list[dict[str, int]] = []
+        entity_indices: list[int] = []
+        for i in range(n_entities):
+            for t in range(seq_lens[i]):
+                row = {sub_col: vals[i][t] for sub_col, vals in data_cols.items()}
+                rows.append(row)
+                entity_indices.append(i)
+
+        if not rows:
+            return pd.DataFrame(columns=self._encoder.features)
+
+        df_flat = pd.DataFrame(rows)
+        features = self._encoder.features
+        df = decode_columns(df_flat.to_dict(orient="list"), features, column_stats)
+
+        group_by = self._encoder._group_by
+        if group_by:
+            if (parent is not None
+                    and self._encoder._parent_key
+                    and self._encoder._parent_key in parent.columns):
+                key_values = parent[self._encoder._parent_key].values
+                df[group_by] = [
+                    key_values[idx] if idx < len(key_values) else idx
+                    for idx in entity_indices
+                ]
+            else:
+                df[group_by] = entity_indices
+            cols = [group_by] + [c for c in df.columns if c != group_by]
+            df = df[cols]
+
+        self.status = "ready"
+        logger.info("Generated %d event rows for %d entities", len(df), n_entities)
         return df
 
     def delete(self) -> None:

--- a/examples/multitable.py
+++ b/examples/multitable.py
@@ -1,0 +1,72 @@
+"""
+DataXID SDK — Multi-Table Quickstart
+
+Demonstrates synthesize_tables() with two related tables:
+accounts (parent) and transactions (child with FK).
+
+Requirements:
+    pip install dataxid
+
+Usage:
+    export DATAXID_API_KEY="dx_..."
+    python examples/multitable.py
+"""
+
+import logging
+import os
+
+import pandas as pd
+
+import dataxid
+from dataxid import Table
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+
+dataxid.api_key = os.environ.get("DATAXID_API_KEY", "")
+
+
+def main() -> None:
+    print(f"dataxid v{dataxid.__version__}\n")
+
+    if not dataxid.api_key:
+        print("No DATAXID_API_KEY set.")
+        print("Set export DATAXID_API_KEY='dx_...' to run this example.")
+        return
+
+    df_accounts = pd.DataFrame({
+        "account_id": range(1, 51),
+        "district": [f"district_{i % 5}" for i in range(50)],
+        "frequency": ["monthly", "weekly", "daily"] * 16 + ["monthly", "weekly"],
+        "open_date": pd.date_range("2020-01-01", periods=50, freq="ME"),
+    })
+
+    df_transactions = pd.DataFrame({
+        "account_id": [i for i in range(1, 51) for _ in range(5)],
+        "date": pd.date_range("2023-01-01", periods=250, freq="D"),
+        "amount": [round(50 + i * 3.7, 2) for i in range(250)],
+        "type": ["credit", "debit"] * 125,
+    })
+
+    print(f"Accounts:     {len(df_accounts)} rows")
+    print(f"Transactions: {len(df_transactions)} rows")
+
+    accounts = Table(df_accounts, primary_key="account_id")
+    transactions = Table(df_transactions, foreign_keys={"account_id": accounts})
+
+    synthetic = dataxid.synthesize_tables({
+        "accounts": accounts,
+        "transactions": transactions,
+    })
+
+    print(f"\nSynthetic accounts:     {len(synthetic['accounts'])} rows")
+    print(f"Synthetic transactions: {len(synthetic['transactions'])} rows")
+
+    print("\n--- Synthetic accounts (first 5) ---")
+    print(synthetic["accounts"].head().to_string())
+
+    print("\n--- Synthetic transactions (first 5) ---")
+    print(synthetic["transactions"].head().to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multitable.py
+++ b/examples/multitable.py
@@ -12,7 +12,6 @@ Usage:
     python examples/multitable.py
 """
 
-import logging
 import os
 
 import pandas as pd
@@ -20,7 +19,7 @@ import pandas as pd
 import dataxid
 from dataxid import Table
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+dataxid.enable_logging("info")
 
 dataxid.api_key = os.environ.get("DATAXID_API_KEY", "")
 
@@ -34,17 +33,17 @@ def main() -> None:
         return
 
     df_accounts = pd.DataFrame({
-        "account_id": range(1, 51),
-        "district": [f"district_{i % 5}" for i in range(50)],
-        "frequency": ["monthly", "weekly", "daily"] * 16 + ["monthly", "weekly"],
-        "open_date": pd.date_range("2020-01-01", periods=50, freq="ME"),
+        "account_id": range(1, 101),
+        "district": [f"district_{i % 5}" for i in range(100)],
+        "frequency": ["monthly", "weekly", "daily"] * 33 + ["monthly"],
+        "open_date": pd.date_range("2020-01-01", periods=100, freq="10D"),
     })
 
     df_transactions = pd.DataFrame({
-        "account_id": [i for i in range(1, 51) for _ in range(5)],
-        "date": pd.date_range("2023-01-01", periods=250, freq="D"),
-        "amount": [round(50 + i * 3.7, 2) for i in range(250)],
-        "type": ["credit", "debit"] * 125,
+        "account_id": [i for i in range(1, 101) for _ in range(5)],
+        "date": pd.date_range("2023-01-01", periods=500, freq="D"),
+        "amount": [round(50 + i * 2.5, 2) for i in range(500)],
+        "type": ["credit", "debit"] * 250,
     })
 
     print(f"Accounts:     {len(df_accounts)} rows")

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -14,7 +14,6 @@ Usage:
     python examples/quickstart.py
 """
 
-import logging
 import os
 
 import pandas as pd
@@ -22,7 +21,7 @@ from sklearn.datasets import fetch_openml
 
 import dataxid
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+dataxid.enable_logging("info")
 
 dataxid.api_key = os.environ.get("DATAXID_API_KEY", "")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dataxid"
-version = "0.1.0"
+version = "0.2.0"
 description = "The Synthetic Data API — privacy-preserving synthetic data generation"
 authors = [{ name = "Dataxid", email = "dev@dataxid.com" }]
 requires-python = ">=3.10"


### PR DESCRIPTION
## What

Add multi-table synthesis, sequential/time-series generation, datetime auto-detection, and SDK-level logging. Version bumped to 0.2.0.

## Why

v0.1.0 only supported single-table generation. Users need to synthesize related tables (parent-child) with referential integrity, generate per-entity time series, and have easy access to training logs without manual logging setup.

## How

- `Table` class with `foreign_keys` (dict[str, Table]) for type-safe table references
- `synthesize_tables()` trains tables in topological order, auto-assigns PKs, remaps FKs
- Sequential generation is automatic when foreign keys are present (opt-out via `sequential=False`)
- Datetime columns detected via name patterns + value sampling heuristic
- `enable_logging()` / `disable_logging()` with `DATAXID_LOG` env var (default off, sensitive headers masked, root logger untouched)

## Test Plan

- [x] Existing tests pass
- [x] New tests added (`test_logging.py`)
- [x] Tested manually with `examples/multitable.py` (100 accounts + 500 transactions)