### PR TITLE
feat: validate public API inputs at the boundary (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.1] - 2026-04-29
+
+A hardening release: every public input is validated at the boundary,
+every validation failure raises `InvalidRequestError`. Existing call
+sites upgrade unchanged unless they catch `TypeError` for config errors
+or override `DataxidClient.base_url`.
+
+### Changed
+
+- All validation failures raise `InvalidRequestError`, which inherits
+  from `DataxidError` and `ValueError`. `except ValueError` keeps
+  working; replace `except TypeError` with `except InvalidRequestError`
+  for config errors.
+- `DataxidClient.base_url` must use HTTPS, except for local-development
+  hosts.
+
+### Added
+
+- Invalid inputs to public methods now fail before any network call
+  or training step begins, with the offending parameter named on the
+  exception.
+- `ModelConfig.model_size` and `encoding_types` rejected at
+  construction time when given unknown values.
+- `Table` enforces additional invariants on foreign keys and rejects
+  malformed `tables` dicts in `synthesize_tables`.
+
+### Fixed
+
+- HTTP client joins `base_url` and paths consistently regardless of
+  trailing slashes; parses `Retry-After` in numeric and HTTP-date
+  formats.
+- `enable_logging()` no longer crashes with `AttributeError` on
+  non-string levels.
+- Numeric-discrete decoding reaches the `NULL_TOKEN` path; a default
+  rare-strategy interaction previously masked nulls.
+- Training loss recording preserves legitimate `0.0` values.
+
 ## [0.3.0] - 2026-04-21
 
 This release introduces typed dataclasses for structured generation

--- a/dataxid/__init__.py
+++ b/dataxid/__init__.py
@@ -21,10 +21,7 @@ from __future__ import annotations
 
 __version__ = "0.3.0"
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    import pandas as pd
+import pandas as pd
 
 from dataxid._log import disable_logging, enable_logging
 from dataxid._log import logger as _logger
@@ -150,7 +147,47 @@ def synthesize(
 
     Returns:
         DataFrame with synthetic data (target columns only)
+
+    Raises:
+        InvalidRequestError: If any user input fails validation.
+            Inherits from :class:`ValueError`.
     """
+    if seed is not _UNSET and seed is not None and (
+        not isinstance(seed, int) or isinstance(seed, bool)
+    ):
+        raise InvalidRequestError(
+            f"seed must be an integer or None, got {seed!r}",
+            param="seed",
+        )
+    if diversity is not _UNSET and (
+        not isinstance(diversity, (int, float))
+        or isinstance(diversity, bool)
+        or diversity <= 0
+    ):
+        raise InvalidRequestError(
+            f"diversity must be > 0, got {diversity!r}",
+            param="diversity",
+        )
+    if rare_cutoff is not _UNSET and (
+        not isinstance(rare_cutoff, (int, float))
+        or isinstance(rare_cutoff, bool)
+        or not (0 < rare_cutoff <= 1.0)
+    ):
+        raise InvalidRequestError(
+            f"rare_cutoff must be in (0, 1], got {rare_cutoff!r}",
+            param="rare_cutoff",
+        )
+    if (
+        rare_strategy is not _UNSET
+        and rare_strategy is not None
+        and rare_strategy not in ("mask", "sample")
+    ):
+        raise InvalidRequestError(
+            f"rare_strategy must be 'mask', 'sample', or None, "
+            f"got {rare_strategy!r}",
+            param="rare_strategy",
+        )
+
     n_explicit: int | None = n_samples if n_samples is not _UNSET else None
     if n_explicit is None and synthetic is not None:
         n_explicit = synthetic.n
@@ -266,7 +303,19 @@ def synthesize_tables(
 
     Returns:
         Dict mapping table name to synthetic DataFrame.
+
+    Raises:
+        InvalidRequestError: If any user input fails validation.
+            Inherits from :class:`ValueError`.
     """
+    if seed is not None and (
+        not isinstance(seed, int) or isinstance(seed, bool)
+    ):
+        raise InvalidRequestError(
+            f"seed must be an integer or None, got {seed!r}",
+            param="seed",
+        )
+
     if seed is not None:
         if config is None:
             config = {"seed": seed}
@@ -287,6 +336,26 @@ def synthesize_tables(
         rare_strategy, tables, name="rare_strategy",
         validator=lambda v: v in ("mask", "sample"),
         hint="'mask' or 'sample'",
+    )
+    _validate_per_table_dict(
+        synthetic, tables, name="synthetic",
+        validator=lambda v: isinstance(v, Synthetic),
+        hint="a Synthetic instance",
+    )
+    _validate_per_table_dict(
+        distribution, tables, name="distribution",
+        validator=lambda v: isinstance(v, Distribution),
+        hint="a Distribution instance",
+    )
+    _validate_per_table_dict(
+        bias, tables, name="bias",
+        validator=lambda v: isinstance(v, Bias),
+        hint="a Bias instance",
+    )
+    _validate_per_table_dict(
+        conditions, tables, name="conditions",
+        validator=lambda v: isinstance(v, pd.DataFrame),
+        hint="a pandas DataFrame",
     )
 
     from dataxid._table import (

--- a/dataxid/__init__.py
+++ b/dataxid/__init__.py
@@ -19,7 +19,7 @@ Quick start::
 
 from __future__ import annotations
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 import pandas as pd
 

--- a/dataxid/_log.py
+++ b/dataxid/_log.py
@@ -40,6 +40,11 @@ def enable_logging(level: str = "info") -> None:
     Raises:
         ValueError: If *level* is not a valid Python log level name.
     """
+    if not isinstance(level, str):
+        raise ValueError(
+            f"Invalid log level: {level!r}. "
+            f"Use one of: debug, info, warning, error, critical."
+        )
     numeric = getattr(logging, level.upper(), None)
     if not isinstance(numeric, int):
         raise ValueError(

--- a/dataxid/_log.py
+++ b/dataxid/_log.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 import os
 
+from dataxid.exceptions import InvalidRequestError
+
 logger: logging.Logger = logging.getLogger("dataxid")
 logger.addHandler(logging.NullHandler())
 
@@ -38,18 +40,22 @@ def enable_logging(level: str = "info") -> None:
         level: One of "debug", "info", "warning", "error", "critical".
 
     Raises:
-        ValueError: If *level* is not a valid Python log level name.
+        InvalidRequestError: If *level* is not a valid Python log level
+            name. Inherits from :class:`ValueError` for backward
+            compatibility with ``except ValueError``.
     """
     if not isinstance(level, str):
-        raise ValueError(
+        raise InvalidRequestError(
             f"Invalid log level: {level!r}. "
-            f"Use one of: debug, info, warning, error, critical."
+            f"Use one of: debug, info, warning, error, critical.",
+            param="level",
         )
     numeric = getattr(logging, level.upper(), None)
     if not isinstance(numeric, int):
-        raise ValueError(
+        raise InvalidRequestError(
             f"Invalid log level: {level!r}. "
-            f"Use one of: debug, info, warning, error, critical."
+            f"Use one of: debug, info, warning, error, critical.",
+            param="level",
         )
 
     logger.setLevel(numeric)

--- a/dataxid/_table.py
+++ b/dataxid/_table.py
@@ -88,10 +88,22 @@ class Table:
                     f"{list(self.data.columns)}.",
                     param="foreign_keys",
                 )
+            if fk_col == self.primary_key:
+                raise InvalidRequestError(
+                    f"Foreign key '{fk_col}' cannot also be the primary_key "
+                    f"of the same table.",
+                    param="foreign_keys",
+                )
             if not isinstance(parent_table, Table):
                 raise InvalidRequestError(
                     f"foreign_keys values must be Table instances, got "
                     f"{type(parent_table).__name__} for key '{fk_col}'.",
+                    param="foreign_keys",
+                )
+            if parent_table is self:
+                raise InvalidRequestError(
+                    f"Foreign key '{fk_col}' references the same Table "
+                    f"instance — self-references are not supported.",
                     param="foreign_keys",
                 )
             if parent_table.primary_key is None:
@@ -160,8 +172,27 @@ def _resolve_fk_targets(
 
 def _validate_tables(tables: dict[str, Table]) -> None:
     """Validate table definitions: FK targets exist, referenced tables have PK, no cycles."""
+    if not isinstance(tables, dict):
+        raise InvalidRequestError(
+            f"tables must be a dict mapping name to Table, got "
+            f"{type(tables).__name__}.",
+            param="tables",
+        )
     if not tables:
         raise InvalidRequestError("tables must contain at least one table.", param="tables")
+
+    for name, tbl in tables.items():
+        if not isinstance(name, str):
+            raise InvalidRequestError(
+                f"tables keys must be strings, got {type(name).__name__} ({name!r}).",
+                param="tables",
+            )
+        if not isinstance(tbl, Table):
+            raise InvalidRequestError(
+                f"tables[{name!r}] must be a Table instance, got "
+                f"{type(tbl).__name__}.",
+                param="tables",
+            )
 
     _resolve_fk_targets(tables)
 

--- a/dataxid/client/_http.py
+++ b/dataxid/client/_http.py
@@ -90,6 +90,48 @@ _ERROR_MAP = {
 }
 
 
+_LOCALHOST_HOSTS: tuple[str, ...] = ("localhost", "127.0.0.1", "::1", "0.0.0.0")
+
+
+def _validate_base_url(base_url: str) -> None:
+    """Reject non-HTTPS base URLs to prevent plaintext API-key exposure.
+
+    HTTP is allowed only for the loopback hosts listed in
+    :data:`_LOCALHOST_HOSTS` so local development stays unaffected.
+    """
+    stripped = base_url.strip()
+    if not stripped:
+        raise InvalidRequestError(
+            "base_url must be a non-empty string",
+            param="base_url",
+        )
+    if "://" not in stripped:
+        raise InvalidRequestError(
+            f"base_url must start with https:// (or http:// for localhost), "
+            f"got {base_url!r}",
+            param="base_url",
+        )
+    scheme, _, rest = stripped.partition("://")
+    scheme = scheme.lower()
+    host = rest.split("/", 1)[0].split(":", 1)[0].lower()
+    if scheme == "https":
+        return
+    if scheme == "http" and host in _LOCALHOST_HOSTS:
+        return
+    if scheme == "http":
+        raise InvalidRequestError(
+            f"base_url must use https:// for non-localhost endpoints, got "
+            f"{base_url!r} — sending API requests over HTTP would expose "
+            f"your API key in plaintext.",
+            param="base_url",
+        )
+    raise InvalidRequestError(
+        f"base_url scheme must be https:// (or http:// for localhost), "
+        f"got {scheme!r}://",
+        param="base_url",
+    )
+
+
 class DataxidClient:
     """Low-level HTTP client. Used internally by Model and synthesize()."""
 
@@ -99,6 +141,28 @@ class DataxidClient:
         base_url: str | None = None,
         timeout: float | httpx.Timeout = _DEFAULT_TIMEOUT,
     ):
+        if api_key is not None and not isinstance(api_key, str):
+            raise InvalidRequestError(
+                f"api_key must be a string or None, got {type(api_key).__name__}",
+                param="api_key",
+            )
+        if base_url is not None:
+            if not isinstance(base_url, str):
+                raise InvalidRequestError(
+                    f"base_url must be a string or None, got "
+                    f"{type(base_url).__name__}",
+                    param="base_url",
+                )
+            _validate_base_url(base_url)
+        if not isinstance(timeout, (int, float, httpx.Timeout)) or isinstance(
+            timeout, bool
+        ):
+            raise InvalidRequestError(
+                f"timeout must be a number or httpx.Timeout, got "
+                f"{type(timeout).__name__}",
+                param="timeout",
+            )
+
         self._api_key = api_key
         self._base_url = base_url
         self._timeout = timeout
@@ -115,7 +179,9 @@ class DataxidClient:
 
     @property
     def base_url(self) -> str:
-        return self._base_url or dataxid.base_url
+        url = self._base_url or dataxid.base_url
+        _validate_base_url(url)
+        return url
 
     def post(
         self, path: str, json: dict[str, Any] | None = None, idempotent: bool = True,

--- a/dataxid/client/_http.py
+++ b/dataxid/client/_http.py
@@ -6,10 +6,12 @@ HTTP client for DataXID API.
 Handles auth, retry, timeout, idempotency keys, and structured error parsing.
 """
 
+import email.utils
 import os
 import random
 import time
 import uuid
+from datetime import datetime, timezone
 from typing import Any
 
 import httpx
@@ -31,6 +33,53 @@ _MAX_RETRIES = 3
 _RETRY_STATUS_CODES = {408, 429, 500, 502, 503, 504}
 _BACKOFF_BASE = 0.5
 _BACKOFF_MAX = 8.0
+
+# Upper bound for honoured ``Retry-After`` hints. A misconfigured or hostile
+# server cannot put the SDK to sleep for hours; longer hints fall back to
+# this cap so callers can still cancel within a reasonable window.
+_MAX_RETRY_AFTER_SECONDS = 3600.0
+
+
+def _parse_retry_after(raw: str | None) -> float | None:
+    """Parse a ``Retry-After`` header value into a delay in seconds.
+
+    Per :rfc:`9110#section-10.2.3` the header value is either ``delta-seconds``
+    (an integer number of seconds) or an ``HTTP-date``. We accept both forms
+    — plus a fractional-seconds variant some servers emit — and return
+    ``None`` for anything else, so callers fall back to exponential backoff.
+
+    Negative deltas, past dates, and values exceeding
+    :data:`_MAX_RETRY_AFTER_SECONDS` are normalised to keep the SDK
+    responsive even when the server returns a degenerate hint.
+    """
+    if not raw:
+        return None
+
+    raw = raw.strip()
+    if not raw:
+        return None
+
+    try:
+        seconds: float | None = float(raw)
+    except ValueError:
+        seconds = _http_date_to_seconds(raw)
+
+    if seconds is None or seconds < 0:
+        return None
+    return min(seconds, _MAX_RETRY_AFTER_SECONDS)
+
+
+def _http_date_to_seconds(raw: str) -> float | None:
+    """Convert an RFC 1123 ``HTTP-date`` into seconds from "now"."""
+    try:
+        parsed = email.utils.parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return (parsed - datetime.now(tz=timezone.utc)).total_seconds()
 
 _ERROR_MAP = {
     "authentication_error": AuthenticationError,
@@ -87,7 +136,7 @@ class DataxidClient:
         params: dict[str, Any] | None = None,
         idempotent: bool = False,
     ) -> dict | None:
-        url = f"{self.base_url}{path}"
+        url = f"{self.base_url.rstrip('/')}/{path.lstrip('/')}"
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
@@ -142,14 +191,11 @@ class DataxidClient:
     def _sleep_before_retry(
         attempt: int, response: httpx.Response | None = None,
     ) -> None:
-        retry_after = None
-        if response is not None:
-            raw = response.headers.get("Retry-After")
-            if raw:
-                try:
-                    retry_after = float(raw)
-                except ValueError:
-                    retry_after = None
+        retry_after = (
+            _parse_retry_after(response.headers.get("Retry-After"))
+            if response is not None
+            else None
+        )
 
         if retry_after is not None and retry_after > 0:
             delay = retry_after
@@ -186,8 +232,9 @@ class DataxidClient:
         if exc_class == InvalidRequestError:
             kwargs["param"] = error.get("param")
         elif exc_class == RateLimitError:
-            retry_after = response.headers.get("Retry-After")
-            kwargs["retry_after"] = float(retry_after) if retry_after else None
+            kwargs["retry_after"] = _parse_retry_after(
+                response.headers.get("Retry-After"),
+            )
         elif exc_class == QuotaExceededError:
             kwargs["usage"] = error.get("usage")
             kwargs["upgrade_url"] = error.get("upgrade_url")

--- a/dataxid/encoder/_wrapper.py
+++ b/dataxid/encoder/_wrapper.py
@@ -73,6 +73,11 @@ class Encoder:
         self._parent_key: str | None = None
         self._seq_data: dict[str, list] | None = None
 
+    @property
+    def protect_rare_enabled(self) -> bool:
+        """Whether rare-category protection is active for this encoder."""
+        return self._protect_rare
+
     def analyze(
         self,
         df: pd.DataFrame,

--- a/dataxid/exceptions.py
+++ b/dataxid/exceptions.py
@@ -18,8 +18,14 @@ class AuthenticationError(DataxidError):
     pass
 
 
-class InvalidRequestError(DataxidError):
-    """Bad request parameters."""
+class InvalidRequestError(DataxidError, ValueError):
+    """Bad request parameters.
+
+    Multi-inherits from :class:`ValueError` so that callers using the
+    Python-idiomatic ``except ValueError`` continue to catch validation
+    failures, while ``except DataxidError`` remains the SDK-wide handler.
+    The ``param`` attribute names the offending field.
+    """
     def __init__(self, message: str, param: str | None = None, **kwargs):
         self.param = param
         super().__init__(message, **kwargs)

--- a/dataxid/pipeline/_decode.py
+++ b/dataxid/pipeline/_decode.py
@@ -89,7 +89,7 @@ def _decode_categorical(
 
 def _decode_numeric_discrete(codes: np.ndarray, stats: dict) -> pd.Series:
     dtype = "Float64" if stats["min_decimal"] < 0 else "Int64"
-    values = _decode_categorical(codes, stats)
+    values = _decode_categorical(codes, stats, rare_strategy="mask")
 
     is_rare = values == RARE_TOKEN
     cnt_rare = is_rare.sum()

--- a/dataxid/training/_config.py
+++ b/dataxid/training/_config.py
@@ -14,10 +14,44 @@ import math
 from dataclasses import dataclass, field, replace
 from typing import Literal
 
+from dataxid.encoder._ports import EncodingType
 from dataxid.exceptions import InvalidRequestError
 
 RareStrategy = Literal["mask", "sample"]
 _RARE_STRATEGIES: tuple[str, ...] = ("mask", "sample")
+_MODEL_SIZES: tuple[str, ...] = ("small", "medium", "large")
+_VALID_ENCODING_TYPES: frozenset[str] = frozenset(et.value for et in EncodingType)
+
+
+def _validate_encoding_types(value: object, param: str) -> None:
+    """Validate a ``dict[str, str | EncodingType]`` encoding-override mapping.
+
+    Accepts ``None``. Raises :class:`InvalidRequestError` (param=``param``)
+    if the value is not a dict, has non-string keys, or contains a value
+    outside the :class:`EncodingType` enum.
+    """
+    if value is None:
+        return
+    if not isinstance(value, dict):
+        raise InvalidRequestError(
+            f"{param} must be a dict or None, got {type(value).__name__}",
+            param=param,
+        )
+    for key, val in value.items():
+        if not isinstance(key, str):
+            raise InvalidRequestError(
+                f"{param} keys must be strings, got {type(key).__name__} ({key!r})",
+                param=param,
+            )
+        if isinstance(val, EncodingType):
+            continue
+        if isinstance(val, str) and val in _VALID_ENCODING_TYPES:
+            continue
+        raise InvalidRequestError(
+            f"{param}[{key!r}] must be one of {sorted(_VALID_ENCODING_TYPES)} "
+            f"or an EncodingType enum member, got {val!r}",
+            param=param,
+        )
 
 
 @dataclass(frozen=True)
@@ -333,6 +367,12 @@ class ModelConfig:
     timeout: float = 14400.0
 
     def __post_init__(self) -> None:
+        if self.model_size not in _MODEL_SIZES:
+            raise InvalidRequestError(
+                f"ModelConfig.model_size must be one of {_MODEL_SIZES}, "
+                f"got {self.model_size!r}",
+                param="model_size",
+            )
         self._check_positive_int("embedding_dim", self.embedding_dim)
         self._check_positive_int("batch_size", self.batch_size)
         self._check_positive_int("max_epochs", self.max_epochs)
@@ -345,6 +385,7 @@ class ModelConfig:
         self._check_positive_finite("timeout", self.timeout)
         if self.learning_rate is not None:
             self._check_positive_finite("learning_rate", self.learning_rate)
+        _validate_encoding_types(self.encoding_types, "encoding_types")
 
     @staticmethod
     def _check_positive_int(name: str, value: object) -> None:

--- a/dataxid/training/_config.py
+++ b/dataxid/training/_config.py
@@ -14,6 +14,8 @@ import math
 from dataclasses import dataclass, field, replace
 from typing import Literal
 
+from dataxid.exceptions import InvalidRequestError
+
 RareStrategy = Literal["mask", "sample"]
 _RARE_STRATEGIES: tuple[str, ...] = ("mask", "sample")
 
@@ -54,8 +56,10 @@ class Synthetic:
             ``None`` means "fall back to ``ModelConfig.privacy.rare_strategy``".
 
     Raises:
-        ValueError: If ``diversity <= 0``, ``rare_cutoff`` is outside
-            ``(0, 1]``, or ``n`` is not a positive integer.
+        InvalidRequestError: If ``diversity <= 0``, ``rare_cutoff`` is
+            outside ``(0, 1]``, or ``n`` is not a positive integer.
+            Inherits from :class:`ValueError` for Python-idiomatic
+            ``except ValueError`` handling.
     """
 
     n: int | None = None
@@ -65,22 +69,28 @@ class Synthetic:
     rare_strategy: RareStrategy | None = None
 
     def __post_init__(self) -> None:
-        if self.n is not None and (not isinstance(self.n, int) or self.n <= 0):
-            raise ValueError(
-                f"Synthetic.n must be a positive integer or None, got {self.n!r}"
+        if self.n is not None and (
+            not isinstance(self.n, int) or isinstance(self.n, bool) or self.n <= 0
+        ):
+            raise InvalidRequestError(
+                f"Synthetic.n must be a positive integer or None, got {self.n!r}",
+                param="n",
             )
         if self.diversity <= 0:
-            raise ValueError(
-                f"Synthetic.diversity must be > 0, got {self.diversity!r}"
+            raise InvalidRequestError(
+                f"Synthetic.diversity must be > 0, got {self.diversity!r}",
+                param="diversity",
             )
         if not (0 < self.rare_cutoff <= 1):
-            raise ValueError(
-                f"Synthetic.rare_cutoff must be in (0, 1], got {self.rare_cutoff!r}"
+            raise InvalidRequestError(
+                f"Synthetic.rare_cutoff must be in (0, 1], got {self.rare_cutoff!r}",
+                param="rare_cutoff",
             )
         if self.rare_strategy is not None and self.rare_strategy not in _RARE_STRATEGIES:
-            raise ValueError(
+            raise InvalidRequestError(
                 f"Synthetic.rare_strategy must be 'mask', 'sample', or None, "
-                f"got {self.rare_strategy!r}"
+                f"got {self.rare_strategy!r}",
+                param="rare_strategy",
             )
 
 
@@ -109,8 +119,9 @@ class Bias:
             of categorical column names, and must not include ``target``.
 
     Raises:
-        ValueError: If ``target`` is empty / not a string, ``sensitive``
-            is empty, contains non-strings, or includes ``target``.
+        InvalidRequestError: If ``target`` is empty / not a string,
+            ``sensitive`` is empty, contains non-strings, or includes
+            ``target``. Inherits from :class:`ValueError`.
     """
 
     target: str
@@ -118,18 +129,24 @@ class Bias:
 
     def __post_init__(self) -> None:
         if not isinstance(self.target, str) or not self.target.strip():
-            raise ValueError(
-                f"Bias.target must be a non-empty string, got {self.target!r}"
+            raise InvalidRequestError(
+                f"Bias.target must be a non-empty string, got {self.target!r}",
+                param="target",
             )
         if not self.sensitive:
-            raise ValueError("Bias.sensitive must be a non-empty list")
+            raise InvalidRequestError(
+                "Bias.sensitive must be a non-empty list",
+                param="sensitive",
+            )
         if any(not isinstance(s, str) or not s.strip() for s in self.sensitive):
-            raise ValueError(
-                "Bias.sensitive entries must be non-empty strings"
+            raise InvalidRequestError(
+                "Bias.sensitive entries must be non-empty strings",
+                param="sensitive",
             )
         if self.target in self.sensitive:
-            raise ValueError(
-                f"Bias.target ({self.target!r}) cannot appear in sensitive"
+            raise InvalidRequestError(
+                f"Bias.target ({self.target!r}) cannot appear in sensitive",
+                param="target",
             )
 
 
@@ -158,8 +175,10 @@ class Distribution:
             they need not sum to exactly 1.0.
 
     Raises:
-        ValueError: If ``column`` is empty / not a string, ``probabilities``
-            is empty, or any probability is negative.
+        InvalidRequestError: If ``column`` is empty / not a string,
+            ``probabilities`` is empty, contains non-string keys, or has
+            negative / non-finite values. Inherits from
+            :class:`ValueError`.
     """
 
     column: str
@@ -167,38 +186,47 @@ class Distribution:
 
     def __post_init__(self) -> None:
         if not isinstance(self.column, str) or not self.column.strip():
-            raise ValueError(
-                f"Distribution.column must be a non-empty string, got {self.column!r}"
+            raise InvalidRequestError(
+                f"Distribution.column must be a non-empty string, got {self.column!r}",
+                param="column",
             )
         if not self.probabilities:
-            raise ValueError("Distribution.probabilities must be non-empty")
+            raise InvalidRequestError(
+                "Distribution.probabilities must be non-empty",
+                param="probabilities",
+            )
         for key, value in self.probabilities.items():
             if not isinstance(key, str):
-                raise TypeError(
+                raise InvalidRequestError(
                     f"Distribution.probabilities keys must be strings, got "
                     f"{type(key).__name__} ({key!r}). Numeric category values "
                     f"must be passed as their string representation, e.g. "
-                    f"{{'25': 0.5}} not {{25: 0.5}}."
+                    f"{{'25': 0.5}} not {{25: 0.5}}.",
+                    param="probabilities",
                 )
             if not key.strip():
-                raise ValueError(
+                raise InvalidRequestError(
                     "Distribution.probabilities keys must be non-empty / "
-                    f"non-whitespace strings, got {key!r}"
+                    f"non-whitespace strings, got {key!r}",
+                    param="probabilities",
                 )
             if not isinstance(value, (int, float)) or isinstance(value, bool):
-                raise ValueError(
+                raise InvalidRequestError(
                     f"Distribution.probabilities[{key!r}] must be a real number, "
-                    f"got {value!r}"
+                    f"got {value!r}",
+                    param="probabilities",
                 )
             if math.isnan(value) or math.isinf(value):
-                raise ValueError(
+                raise InvalidRequestError(
                     f"Distribution.probabilities[{key!r}] must be finite, "
-                    f"got {value!r}"
+                    f"got {value!r}",
+                    param="probabilities",
                 )
             if value < 0:
-                raise ValueError(
+                raise InvalidRequestError(
                     f"Distribution.probabilities[{key!r}] must be non-negative, "
-                    f"got {value!r}"
+                    f"got {value!r}",
+                    param="probabilities",
                 )
 
 
@@ -251,17 +279,20 @@ class Privacy:
 
     def __post_init__(self) -> None:
         if self.rare_strategy not in _RARE_STRATEGIES:
-            raise ValueError(
+            raise InvalidRequestError(
                 f"Privacy.rare_strategy must be 'mask' or 'sample', "
-                f"got {self.rare_strategy!r}"
+                f"got {self.rare_strategy!r}",
+                param="rare_strategy",
             )
         if not isinstance(self.noise, (int, float)) or isinstance(self.noise, bool):
-            raise ValueError(
-                f"Privacy.noise must be a real number, got {self.noise!r}"
+            raise InvalidRequestError(
+                f"Privacy.noise must be a real number, got {self.noise!r}",
+                param="noise",
             )
         if math.isnan(self.noise) or math.isinf(self.noise) or self.noise < 0:
-            raise ValueError(
-                f"Privacy.noise must be a non-negative finite number, got {self.noise!r}"
+            raise InvalidRequestError(
+                f"Privacy.noise must be a non-negative finite number, got {self.noise!r}",
+                param="noise",
             )
 
 
@@ -318,15 +349,17 @@ class ModelConfig:
     @staticmethod
     def _check_positive_int(name: str, value: object) -> None:
         if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-            raise ValueError(
-                f"ModelConfig.{name} must be a positive integer, got {value!r}"
+            raise InvalidRequestError(
+                f"ModelConfig.{name} must be a positive integer, got {value!r}",
+                param=name,
             )
 
     @staticmethod
     def _check_non_negative_int(name: str, value: object) -> None:
         if not isinstance(value, int) or isinstance(value, bool) or value < 0:
-            raise ValueError(
-                f"ModelConfig.{name} must be a non-negative integer, got {value!r}"
+            raise InvalidRequestError(
+                f"ModelConfig.{name} must be a non-negative integer, got {value!r}",
+                param=name,
             )
 
     @staticmethod
@@ -337,8 +370,9 @@ class ModelConfig:
             or math.isnan(value)
             or not (0 < value < 1)
         ):
-            raise ValueError(
-                f"ModelConfig.{name} must be in (0, 1), got {value!r}"
+            raise InvalidRequestError(
+                f"ModelConfig.{name} must be in (0, 1), got {value!r}",
+                param=name,
             )
 
     @staticmethod
@@ -349,8 +383,9 @@ class ModelConfig:
             or math.isnan(value)
             or not (0 <= value < 1)
         ):
-            raise ValueError(
-                f"ModelConfig.{name} must be in [0, 1), got {value!r}"
+            raise InvalidRequestError(
+                f"ModelConfig.{name} must be in [0, 1), got {value!r}",
+                param=name,
             )
 
     @staticmethod
@@ -362,8 +397,9 @@ class ModelConfig:
             or math.isinf(value)
             or value < 0
         ):
-            raise ValueError(
-                f"ModelConfig.{name} must be a non-negative finite number, got {value!r}"
+            raise InvalidRequestError(
+                f"ModelConfig.{name} must be a non-negative finite number, got {value!r}",
+                param=name,
             )
 
     @staticmethod
@@ -375,8 +411,9 @@ class ModelConfig:
             or math.isinf(value)
             or value <= 0
         ):
-            raise ValueError(
-                f"ModelConfig.{name} must be a positive finite number, got {value!r}"
+            raise InvalidRequestError(
+                f"ModelConfig.{name} must be a positive finite number, got {value!r}",
+                param=name,
             )
 
     def to_dict(self) -> dict:
@@ -405,15 +442,29 @@ def _resolve_config(config: dict | ModelConfig | None) -> ModelConfig:
             if privacy is None:
                 data["privacy"] = Privacy()
             elif isinstance(privacy, dict):
-                data["privacy"] = Privacy(**privacy)
+                try:
+                    data["privacy"] = Privacy(**privacy)
+                except TypeError as exc:
+                    raise InvalidRequestError(
+                        f"config['privacy'] contains an unknown field: {exc}",
+                        param="config",
+                    ) from exc
             elif not isinstance(privacy, Privacy):
-                raise TypeError(
+                raise InvalidRequestError(
                     f"config['privacy'] must be a Privacy instance, dict, or None, "
-                    f"got {type(privacy).__name__}"
+                    f"got {type(privacy).__name__}",
+                    param="config",
                 )
-        return ModelConfig(**data)
-    raise TypeError(
-        f"config must be a ModelConfig instance or dict, got {type(config).__name__}"
+        try:
+            return ModelConfig(**data)
+        except TypeError as exc:
+            raise InvalidRequestError(
+                f"config contains an unknown field: {exc}",
+                param="config",
+            ) from exc
+    raise InvalidRequestError(
+        f"config must be a ModelConfig instance or dict, got {type(config).__name__}",
+        param="config",
     )
 
 

--- a/dataxid/training/_config.py
+++ b/dataxid/training/_config.py
@@ -10,10 +10,12 @@ Plain dicts are accepted for backwards-compatible ergonomics; see
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field, replace
 from typing import Literal
 
 RareStrategy = Literal["mask", "sample"]
+_RARE_STRATEGIES: tuple[str, ...] = ("mask", "sample")
 
 
 @dataclass(frozen=True)
@@ -75,6 +77,11 @@ class Synthetic:
             raise ValueError(
                 f"Synthetic.rare_cutoff must be in (0, 1], got {self.rare_cutoff!r}"
             )
+        if self.rare_strategy is not None and self.rare_strategy not in _RARE_STRATEGIES:
+            raise ValueError(
+                f"Synthetic.rare_strategy must be 'mask', 'sample', or None, "
+                f"got {self.rare_strategy!r}"
+            )
 
 
 @dataclass(frozen=True)
@@ -110,13 +117,13 @@ class Bias:
     sensitive: list[str]
 
     def __post_init__(self) -> None:
-        if not isinstance(self.target, str) or not self.target:
+        if not isinstance(self.target, str) or not self.target.strip():
             raise ValueError(
                 f"Bias.target must be a non-empty string, got {self.target!r}"
             )
         if not self.sensitive:
             raise ValueError("Bias.sensitive must be a non-empty list")
-        if any(not isinstance(s, str) or not s for s in self.sensitive):
+        if any(not isinstance(s, str) or not s.strip() for s in self.sensitive):
             raise ValueError(
                 "Bias.sensitive entries must be non-empty strings"
             )
@@ -159,16 +166,40 @@ class Distribution:
     probabilities: dict[str, float]
 
     def __post_init__(self) -> None:
-        if not isinstance(self.column, str) or not self.column:
+        if not isinstance(self.column, str) or not self.column.strip():
             raise ValueError(
                 f"Distribution.column must be a non-empty string, got {self.column!r}"
             )
         if not self.probabilities:
             raise ValueError("Distribution.probabilities must be non-empty")
-        if any(p < 0 for p in self.probabilities.values()):
-            raise ValueError(
-                "Distribution.probabilities must be non-negative"
-            )
+        for key, value in self.probabilities.items():
+            if not isinstance(key, str):
+                raise TypeError(
+                    f"Distribution.probabilities keys must be strings, got "
+                    f"{type(key).__name__} ({key!r}). Numeric category values "
+                    f"must be passed as their string representation, e.g. "
+                    f"{{'25': 0.5}} not {{25: 0.5}}."
+                )
+            if not key.strip():
+                raise ValueError(
+                    "Distribution.probabilities keys must be non-empty / "
+                    f"non-whitespace strings, got {key!r}"
+                )
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                raise ValueError(
+                    f"Distribution.probabilities[{key!r}] must be a real number, "
+                    f"got {value!r}"
+                )
+            if math.isnan(value) or math.isinf(value):
+                raise ValueError(
+                    f"Distribution.probabilities[{key!r}] must be finite, "
+                    f"got {value!r}"
+                )
+            if value < 0:
+                raise ValueError(
+                    f"Distribution.probabilities[{key!r}] must be non-negative, "
+                    f"got {value!r}"
+                )
 
 
 @dataclass
@@ -218,6 +249,21 @@ class Privacy:
     enabled: bool = False
     noise: float = 0.1
 
+    def __post_init__(self) -> None:
+        if self.rare_strategy not in _RARE_STRATEGIES:
+            raise ValueError(
+                f"Privacy.rare_strategy must be 'mask' or 'sample', "
+                f"got {self.rare_strategy!r}"
+            )
+        if not isinstance(self.noise, (int, float)) or isinstance(self.noise, bool):
+            raise ValueError(
+                f"Privacy.noise must be a real number, got {self.noise!r}"
+            )
+        if math.isnan(self.noise) or math.isinf(self.noise) or self.noise < 0:
+            raise ValueError(
+                f"Privacy.noise must be a non-negative finite number, got {self.noise!r}"
+            )
+
 
 @dataclass
 class ModelConfig:
@@ -255,6 +301,84 @@ class ModelConfig:
     seed: int | None = None
     timeout: float = 14400.0
 
+    def __post_init__(self) -> None:
+        self._check_positive_int("embedding_dim", self.embedding_dim)
+        self._check_positive_int("batch_size", self.batch_size)
+        self._check_positive_int("max_epochs", self.max_epochs)
+        self._check_positive_int("accumulation_steps", self.accumulation_steps)
+        self._check_non_negative_int("early_stop_patience", self.early_stop_patience)
+        self._check_unit_interval_open("val_split", self.val_split)
+        self._check_unit_interval_closed_left("label_smoothing", self.label_smoothing)
+        self._check_unit_interval_closed_left("embedding_dropout", self.embedding_dropout)
+        self._check_non_negative_finite("time_limit_seconds", self.time_limit_seconds)
+        self._check_positive_finite("timeout", self.timeout)
+        if self.learning_rate is not None:
+            self._check_positive_finite("learning_rate", self.learning_rate)
+
+    @staticmethod
+    def _check_positive_int(name: str, value: object) -> None:
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise ValueError(
+                f"ModelConfig.{name} must be a positive integer, got {value!r}"
+            )
+
+    @staticmethod
+    def _check_non_negative_int(name: str, value: object) -> None:
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ValueError(
+                f"ModelConfig.{name} must be a non-negative integer, got {value!r}"
+            )
+
+    @staticmethod
+    def _check_unit_interval_open(name: str, value: object) -> None:
+        if (
+            not isinstance(value, (int, float))
+            or isinstance(value, bool)
+            or math.isnan(value)
+            or not (0 < value < 1)
+        ):
+            raise ValueError(
+                f"ModelConfig.{name} must be in (0, 1), got {value!r}"
+            )
+
+    @staticmethod
+    def _check_unit_interval_closed_left(name: str, value: object) -> None:
+        if (
+            not isinstance(value, (int, float))
+            or isinstance(value, bool)
+            or math.isnan(value)
+            or not (0 <= value < 1)
+        ):
+            raise ValueError(
+                f"ModelConfig.{name} must be in [0, 1), got {value!r}"
+            )
+
+    @staticmethod
+    def _check_non_negative_finite(name: str, value: object) -> None:
+        if (
+            not isinstance(value, (int, float))
+            or isinstance(value, bool)
+            or math.isnan(value)
+            or math.isinf(value)
+            or value < 0
+        ):
+            raise ValueError(
+                f"ModelConfig.{name} must be a non-negative finite number, got {value!r}"
+            )
+
+    @staticmethod
+    def _check_positive_finite(name: str, value: object) -> None:
+        if (
+            not isinstance(value, (int, float))
+            or isinstance(value, bool)
+            or math.isnan(value)
+            or math.isinf(value)
+            or value <= 0
+        ):
+            raise ValueError(
+                f"ModelConfig.{name} must be a positive finite number, got {value!r}"
+            )
+
     def to_dict(self) -> dict:
         """Serialize to a plain dict."""
         data = dict(self.__dict__)
@@ -276,11 +400,17 @@ def _resolve_config(config: dict | ModelConfig | None) -> ModelConfig:
         return config
     if isinstance(config, dict):
         data = dict(config)
-        privacy = data.get("privacy")
-        if isinstance(privacy, dict):
-            data["privacy"] = Privacy(**privacy)
-        elif privacy is None and "privacy" in data:
-            data["privacy"] = Privacy()
+        if "privacy" in data:
+            privacy = data["privacy"]
+            if privacy is None:
+                data["privacy"] = Privacy()
+            elif isinstance(privacy, dict):
+                data["privacy"] = Privacy(**privacy)
+            elif not isinstance(privacy, Privacy):
+                raise TypeError(
+                    f"config['privacy'] must be a Privacy instance, dict, or None, "
+                    f"got {type(privacy).__name__}"
+                )
         return ModelConfig(**data)
     raise TypeError(
         f"config must be a ModelConfig instance or dict, got {type(config).__name__}"

--- a/dataxid/training/_frozen.py
+++ b/dataxid/training/_frozen.py
@@ -125,18 +125,20 @@ def _process_async_result(model: Model, result: dict, max_epochs: int) -> None: 
     model.val_losses = []
     model.stopped_early = result.get("early_stopped", False)
 
-    final_train = result.get("train_loss") or 0
-    final_val = result.get("val_loss") or 0
+    final_train = result.get("train_loss")
+    final_val = result.get("val_loss")
 
-    if final_train:
+    if final_train is not None:
         model.train_losses.append(final_train)
-    if final_val:
+    if final_val is not None:
         model.val_losses.append(final_val)
 
     logger.info(
-        "Training completed: %d epochs, train_loss=%.4f, val_loss=%.4f, "
+        "Training completed: %d epochs, train_loss=%s, val_loss=%s, "
         "early_stopped=%s, duration=%.1fs",
-        result.get("epochs", 0), final_train, final_val,
+        result.get("epochs", 0),
+        f"{final_train:.4f}" if final_train is not None else "n/a",
+        f"{final_val:.4f}" if final_val is not None else "n/a",
         model.stopped_early, result.get("duration_seconds", 0),
     )
     model.status = "ready"
@@ -158,16 +160,21 @@ def _process_sync_result(model: Model, data: dict, max_epochs: int) -> None:
 
         ckpt = " *" if e.get("is_checkpoint") else ""
         logger.info(
-            "Epoch %s/%d: train=%.4f, val=%.4f, lr=%.6f%s",
+            "Epoch %s/%d: train=%s, val=%s, lr=%.6f%s",
             e.get("epoch", "?"), max_epochs,
-            t_loss or 0, v_loss or 0, e.get("learning_rate", 0), ckpt,
+            f"{t_loss:.4f}" if t_loss is not None else "n/a",
+            f"{v_loss:.4f}" if v_loss is not None else "n/a",
+            e.get("learning_rate", 0), ckpt,
         )
 
-    final_train = data.get("train_loss") or 0
-    final_val = data.get("val_loss") or 0
+    final_train = data.get("train_loss")
+    final_val = data.get("val_loss")
     logger.info(
-        "Training completed: %d epochs, train_loss=%.4f, val_loss=%.4f, "
+        "Training completed: %d epochs, train_loss=%s, val_loss=%s, "
         "early_stopped=%s",
-        data.get("epochs", 0), final_train, final_val, model.stopped_early,
+        data.get("epochs", 0),
+        f"{final_train:.4f}" if final_train is not None else "n/a",
+        f"{final_val:.4f}" if final_val is not None else "n/a",
+        model.stopped_early,
     )
     model.status = "ready"

--- a/dataxid/training/_model.py
+++ b/dataxid/training/_model.py
@@ -554,6 +554,41 @@ class Model:
             rare_strategy, synthetic, "rare_strategy", None
         )
 
+        if (
+            not isinstance(diversity_effective, (int, float))
+            or isinstance(diversity_effective, bool)
+            or diversity_effective <= 0
+        ):
+            raise InvalidRequestError(
+                f"diversity must be > 0, got {diversity_effective!r}",
+                param="diversity",
+            )
+        if (
+            not isinstance(rare_cutoff_effective, (int, float))
+            or isinstance(rare_cutoff_effective, bool)
+            or not (0 < rare_cutoff_effective <= 1.0)
+        ):
+            raise InvalidRequestError(
+                f"rare_cutoff must be in (0, 1], got {rare_cutoff_effective!r}",
+                param="rare_cutoff",
+            )
+        if (
+            rare_strategy_effective is not None
+            and rare_strategy_effective not in _RARE_STRATEGY_VALUES
+        ):
+            raise InvalidRequestError(
+                f"rare_strategy must be one of {_RARE_STRATEGY_VALUES}, "
+                f"got {rare_strategy_effective!r}",
+                param="rare_strategy",
+            )
+        if seed_effective is not None and (
+            not isinstance(seed_effective, int) or isinstance(seed_effective, bool)
+        ):
+            raise InvalidRequestError(
+                f"seed must be an integer or None, got {seed_effective!r}",
+                param="seed",
+            )
+
         return self._generate_core(
             n_samples=n_effective,
             conditions=conditions,
@@ -584,25 +619,15 @@ class Model:
 
         The ``imputation`` argument is only set by :meth:`impute` — public
         callers should go through :meth:`generate` instead.
+
+        Invariant (enforced by every public caller):
+            * ``diversity > 0``
+            * ``0 < rare_cutoff <= 1``
+            * ``rare_strategy`` is one of ``_RARE_STRATEGY_VALUES`` or ``None``
+            * ``seed`` is an ``int`` or ``None``
         """
-        if diversity <= 0:
-            raise InvalidRequestError(
-                f"diversity must be > 0, got {diversity}",
-                param="diversity",
-            )
-        if not (0 < rare_cutoff <= 1.0):
-            raise InvalidRequestError(
-                f"rare_cutoff must be in (0, 1], got {rare_cutoff}",
-                param="rare_cutoff",
-            )
         if rare_strategy is None:
             rare_strategy = self._config.privacy.rare_strategy
-        if rare_strategy not in _RARE_STRATEGY_VALUES:
-            raise InvalidRequestError(
-                f"rare_strategy must be one of {_RARE_STRATEGY_VALUES}, "
-                f"got {rare_strategy!r}",
-                param="rare_strategy",
-            )
 
         ctx = parent if parent is not None else self._parent
 
@@ -1007,6 +1032,43 @@ class Model:
                 if field_name not in kwargs:
                     kwargs[field_name] = getattr(synthetic, field_name)
                 # else: explicit kwarg wins over preset
+
+        if "diversity" in kwargs:
+            div = kwargs["diversity"]
+            if (
+                not isinstance(div, (int, float))
+                or isinstance(div, bool)
+                or div <= 0
+            ):
+                raise InvalidRequestError(
+                    f"diversity must be > 0, got {div!r}", param="diversity"
+                )
+        if "rare_cutoff" in kwargs:
+            rc = kwargs["rare_cutoff"]
+            if (
+                not isinstance(rc, (int, float))
+                or isinstance(rc, bool)
+                or not (0 < rc <= 1.0)
+            ):
+                raise InvalidRequestError(
+                    f"rare_cutoff must be in (0, 1], got {rc!r}",
+                    param="rare_cutoff",
+                )
+        if kwargs.get("rare_strategy") is not None and (
+            kwargs["rare_strategy"] not in _RARE_STRATEGY_VALUES
+        ):
+            raise InvalidRequestError(
+                f"rare_strategy must be one of {_RARE_STRATEGY_VALUES}, "
+                f"got {kwargs['rare_strategy']!r}",
+                param="rare_strategy",
+            )
+        if kwargs.get("seed") is not None and (
+            not isinstance(kwargs["seed"], int) or isinstance(kwargs["seed"], bool)
+        ):
+            raise InvalidRequestError(
+                f"seed must be an integer or None, got {kwargs['seed']!r}",
+                param="seed",
+            )
 
         def _single_draw() -> pd.DataFrame:
             return self._generate_core(

--- a/dataxid/training/_model.py
+++ b/dataxid/training/_model.py
@@ -61,17 +61,18 @@ def _normalize_distribution(distribution: Distribution | None) -> dict | None:
     """Normalize a :class:`Distribution` input into its plain-dict form.
 
     Accepts only :class:`Distribution` instances (or ``None``). Dict inputs
-    are rejected with :class:`TypeError`; use ``Distribution(column=..., ...)``
-    instead.
+    are rejected with :class:`InvalidRequestError`; use
+    ``Distribution(column=..., ...)`` instead.
     """
     if distribution is None:
         return None
     if isinstance(distribution, Distribution):
         return asdict(distribution)
-    raise TypeError(
+    raise InvalidRequestError(
         "distribution must be a Distribution instance or None, got "
         f"{type(distribution).__name__}. Use dataxid.Distribution(...) — "
-        "dict inputs are no longer supported as of v0.3.0."
+        "dict inputs are no longer supported as of v0.3.0.",
+        param="distribution",
     )
 
 
@@ -101,16 +102,17 @@ def _merge_n(n_samples: int | None, synthetic: Synthetic | None) -> int | None:
     - Both unset → ``None`` (caller / downstream decides).
     - Only one set → that value.
     - Both set and equal → that value.
-    - Both set but conflicting → :class:`ValueError`.
+    - Both set but conflicting → :class:`InvalidRequestError`.
     """
     preset_n = synthetic.n if synthetic is not None else None
     if n_samples is None:
         return preset_n
     if preset_n is None or preset_n == n_samples:
         return n_samples
-    raise ValueError(
+    raise InvalidRequestError(
         f"n_samples ({n_samples}) conflicts with synthetic.n ({preset_n}). "
-        "Pass only one."
+        "Pass only one.",
+        param="n_samples",
     )
 
 
@@ -118,17 +120,18 @@ def _normalize_bias(bias: Bias | None) -> dict | None:
     """Normalize a :class:`Bias` input into its plain-dict form.
 
     Accepts only :class:`Bias` instances (or ``None``). Dict inputs are
-    rejected with :class:`TypeError`; use ``Bias(target=..., sensitive=...)``
-    instead.
+    rejected with :class:`InvalidRequestError`; use
+    ``Bias(target=..., sensitive=...)`` instead.
     """
     if bias is None:
         return None
     if isinstance(bias, Bias):
         return asdict(bias)
-    raise TypeError(
+    raise InvalidRequestError(
         "bias must be a Bias instance or None, got "
         f"{type(bias).__name__}. Use dataxid.Bias(...) — "
-        "dict inputs are no longer supported as of v0.3.0."
+        "dict inputs are no longer supported as of v0.3.0.",
+        param="bias",
     )
 
 
@@ -179,7 +182,10 @@ def _resolve_pick(
     if callable(pick) and not isinstance(pick, str):
         return pick, False
     if pick not in _PICK_FN_MAP:
-        raise ValueError(f"Unknown pick '{pick}'. Choose from {list(_PICK_FN_MAP)}")
+        raise InvalidRequestError(
+            f"Unknown pick {pick!r}. Choose from {list(_PICK_FN_MAP)}",
+            param="pick",
+        )
     return _PICK_FN_MAP[pick], pick == "all"
 
 
@@ -459,22 +465,24 @@ class Model:
             DataFrame with synthetic data
 
         Raises:
-            ValueError: If both ``n_samples`` and ``conditions`` are provided and
-                their sizes disagree, if ``synthetic.n`` conflicts with
-                ``n_samples``, if ``bias`` is used in sequential mode,
-                or if ``diversity``/``rare_cutoff``/``rare_strategy``
-                are out of range.
-            TypeError: If ``synthetic`` is provided but is not a
-                :class:`Synthetic` instance.
+            InvalidRequestError: For any user-input error, including: both
+                ``n_samples`` and ``conditions`` are provided with
+                disagreeing sizes; ``synthetic.n`` conflicts with
+                ``n_samples``; ``bias`` is used in sequential mode;
+                ``diversity`` / ``rare_cutoff`` / ``rare_strategy`` are
+                out of range; ``synthetic`` is not a :class:`Synthetic`
+                instance. Inherits from :class:`ValueError` for backward
+                compatibility.
 
         Note:
             For filling missing values, use :meth:`impute` — do not attempt
             to emulate imputation through ``generate`` + ``conditions``.
         """
         if synthetic is not None and not isinstance(synthetic, Synthetic):
-            raise TypeError(
+            raise InvalidRequestError(
                 "synthetic must be a Synthetic instance or None, got "
-                f"{type(synthetic).__name__}. Use dataxid.Synthetic(...)."
+                f"{type(synthetic).__name__}. Use dataxid.Synthetic(...).",
+                param="synthetic",
             )
 
         n_effective = _merge_n(n_samples, synthetic)
@@ -517,23 +525,32 @@ class Model:
         callers should go through :meth:`generate` instead.
         """
         if diversity <= 0:
-            raise ValueError(f"diversity must be > 0, got {diversity}")
+            raise InvalidRequestError(
+                f"diversity must be > 0, got {diversity}",
+                param="diversity",
+            )
         if not (0 < rare_cutoff <= 1.0):
-            raise ValueError(f"rare_cutoff must be in (0, 1], got {rare_cutoff}")
+            raise InvalidRequestError(
+                f"rare_cutoff must be in (0, 1], got {rare_cutoff}",
+                param="rare_cutoff",
+            )
         if rare_strategy is None:
             rare_strategy = self._config.privacy.rare_strategy
         if rare_strategy not in _RARE_STRATEGY_VALUES:
-            raise ValueError(
-                f"rare_strategy must be one of "
-                f"{_RARE_STRATEGY_VALUES}, "
-                f"got {rare_strategy!r}"
+            raise InvalidRequestError(
+                f"rare_strategy must be one of {_RARE_STRATEGY_VALUES}, "
+                f"got {rare_strategy!r}",
+                param="rare_strategy",
             )
 
         ctx = parent if parent is not None else self._parent
 
         if self._encoder.is_sequential:
             if bias:
-                raise ValueError("bias is not supported in sequential mode")
+                raise InvalidRequestError(
+                    "bias is not supported in sequential mode",
+                    param="bias",
+                )
             return self._generate_sequential(
                 n_samples=n_samples, conditions=conditions, parent=ctx,
                 seed=seed, distribution=distribution, imputation=imputation,
@@ -543,10 +560,11 @@ class Model:
 
         # flat mode: conditions row count = output row count
         if conditions is not None and n_samples is not None and n_samples != len(conditions):
-            raise ValueError(
+            raise InvalidRequestError(
                 f"n_samples ({n_samples}) conflicts with conditions length "
                 f"({len(conditions)}). When conditions is provided, omit n_samples "
-                f"or set it to len(conditions)."
+                f"or set it to len(conditions).",
+                param="n_samples",
             )
 
         n = (
@@ -712,9 +730,10 @@ class Model:
         fixed_values = None
         if conditions is not None and column_stats and context_key:
             if context_key not in conditions.columns:
-                raise ValueError(
+                raise InvalidRequestError(
                     f"Sequential conditions must contain the foreign key column "
-                    f"'{context_key}'. Got columns: {list(conditions.columns)}"
+                    f"'{context_key}'. Got columns: {list(conditions.columns)}",
+                    param="conditions",
                 )
             pk_col = self._encoder._parent_key
             training_parent = self._parent
@@ -888,9 +907,10 @@ class Model:
 
         synthetic = kwargs.pop("synthetic", None)
         if synthetic is not None and not isinstance(synthetic, Synthetic):
-            raise TypeError(
+            raise InvalidRequestError(
                 "synthetic must be a Synthetic instance or None, got "
-                f"{type(synthetic).__name__}. Use dataxid.Synthetic(...)."
+                f"{type(synthetic).__name__}. Use dataxid.Synthetic(...).",
+                param="synthetic",
             )
         if synthetic is not None:
             if "n_samples" in kwargs:

--- a/dataxid/training/_model.py
+++ b/dataxid/training/_model.py
@@ -272,6 +272,16 @@ class Model:
         self._best_encoder_state: bytes | None = None
         self._encoder_scheduler: torch.optim.lr_scheduler.LRScheduler | None = None
 
+    @property
+    def is_sequential(self) -> bool:
+        """Whether this model was trained on sequential (time-ordered) data."""
+        return self._encoder.is_sequential
+
+    @property
+    def has_context(self) -> bool:
+        """Whether this model uses a parent (context) table."""
+        return self._encoder.has_context
+
     @classmethod
     def create(
         cls,

--- a/dataxid/training/_model.py
+++ b/dataxid/training/_model.py
@@ -317,7 +317,47 @@ class Model:
 
         Returns:
             Trained Model ready for generate()
+
+        Raises:
+            InvalidRequestError: If any user input fails validation.
+                Inherits from :class:`ValueError`.
         """
+        if not isinstance(data, pd.DataFrame):
+            raise InvalidRequestError(
+                f"data must be a pandas DataFrame, got {type(data).__name__}",
+                param="data",
+            )
+        if n_samples is not None and (
+            not isinstance(n_samples, int)
+            or isinstance(n_samples, bool)
+            or n_samples <= 0
+        ):
+            raise InvalidRequestError(
+                f"n_samples must be a positive integer or None, got {n_samples!r}",
+                param="n_samples",
+            )
+        if parent is not None and not isinstance(parent, pd.DataFrame):
+            raise InvalidRequestError(
+                f"parent must be a pandas DataFrame or None, got {type(parent).__name__}",
+                param="parent",
+            )
+        if parent_encoding_types is not None and not isinstance(parent_encoding_types, dict):
+            raise InvalidRequestError(
+                f"parent_encoding_types must be a dict or None, got "
+                f"{type(parent_encoding_types).__name__}",
+                param="parent_encoding_types",
+            )
+        if foreign_key is not None and not isinstance(foreign_key, str):
+            raise InvalidRequestError(
+                f"foreign_key must be a string or None, got {type(foreign_key).__name__}",
+                param="foreign_key",
+            )
+        if parent_key is not None and not isinstance(parent_key, str):
+            raise InvalidRequestError(
+                f"parent_key must be a string or None, got {type(parent_key).__name__}",
+                param="parent_key",
+            )
+
         config = _resolve_config(config)
 
         if parent is not None and foreign_key is not None and parent_key is None:
@@ -478,6 +518,27 @@ class Model:
             For filling missing values, use :meth:`impute` — do not attempt
             to emulate imputation through ``generate`` + ``conditions``.
         """
+        if n_samples is not None and (
+            not isinstance(n_samples, int)
+            or isinstance(n_samples, bool)
+            or n_samples <= 0
+        ):
+            raise InvalidRequestError(
+                f"n_samples must be a positive integer or None, got {n_samples!r}",
+                param="n_samples",
+            )
+        if conditions is not None and not isinstance(conditions, pd.DataFrame):
+            raise InvalidRequestError(
+                f"conditions must be a pandas DataFrame or None, got "
+                f"{type(conditions).__name__}",
+                param="conditions",
+            )
+        if parent is not None and not isinstance(parent, pd.DataFrame):
+            raise InvalidRequestError(
+                f"parent must be a pandas DataFrame or None, got "
+                f"{type(parent).__name__}",
+                param="parent",
+            )
         if synthetic is not None and not isinstance(synthetic, Synthetic):
             raise InvalidRequestError(
                 "synthetic must be a Synthetic instance or None, got "
@@ -892,7 +953,32 @@ class Model:
             df_dirty = df.copy()
             df_dirty.loc[0:10, "age"] = None
             df_clean = model.impute(df_dirty)
+
+        Raises:
+            InvalidRequestError: If any user input fails validation.
+                Inherits from :class:`ValueError`.
         """
+        if not isinstance(X, pd.DataFrame):
+            raise InvalidRequestError(
+                f"X must be a pandas DataFrame, got {type(X).__name__}",
+                param="X",
+            )
+        if parent is not None and not isinstance(parent, pd.DataFrame):
+            raise InvalidRequestError(
+                f"parent must be a pandas DataFrame or None, got "
+                f"{type(parent).__name__}",
+                param="parent",
+            )
+        if (
+            not isinstance(trials, int)
+            or isinstance(trials, bool)
+            or trials <= 0
+        ):
+            raise InvalidRequestError(
+                f"trials must be a positive integer, got {trials!r}",
+                param="trials",
+            )
+
         X_df = X.copy().reset_index(drop=True)
 
         fk = self._encoder._foreign_key

--- a/dataxid/training/_model.py
+++ b/dataxid/training/_model.py
@@ -44,6 +44,7 @@ from dataxid.training._config import (
     RareStrategy,
     Synthetic,
     _resolve_config,
+    _validate_encoding_types,
 )
 from dataxid.training._frozen import train_frozen
 from dataxid.training._seed import _set_seed
@@ -341,12 +342,6 @@ class Model:
                 f"parent must be a pandas DataFrame or None, got {type(parent).__name__}",
                 param="parent",
             )
-        if parent_encoding_types is not None and not isinstance(parent_encoding_types, dict):
-            raise InvalidRequestError(
-                f"parent_encoding_types must be a dict or None, got "
-                f"{type(parent_encoding_types).__name__}",
-                param="parent_encoding_types",
-            )
         if foreign_key is not None and not isinstance(foreign_key, str):
             raise InvalidRequestError(
                 f"foreign_key must be a string or None, got {type(foreign_key).__name__}",
@@ -366,6 +361,7 @@ class Model:
         _validate_context_params(
             data, parent, parent_encoding_types, foreign_key, parent_key,
         )
+        _validate_encoding_types(parent_encoding_types, "parent_encoding_types")
         http = DataxidClient(api_key=api_key, base_url=base_url)
 
         privacy = config.privacy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ packages = ["dataxid"]
 "dataxid/py.typed" = "dataxid/py.typed"
 
 [tool.ruff]
-line-length = 100
+line-length = 120
 target-version = "py310"
 
 [tool.ruff.lint]
@@ -78,6 +78,13 @@ select = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["dataxid"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    "ARG001",
+    "ARG002",
+    "ARG004",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dataxid"
-version = "0.3.0"
+version = "0.3.1"
 description = "The Synthetic Data API — privacy-preserving synthetic data generation"
 authors = [{ name = "Dataxid", email = "dev@dataxid.com" }]
 requires-python = ">=3.10"

--- a/tests/sdk/conftest.py
+++ b/tests/sdk/conftest.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Shared fixtures for SDK tests.
+
+Provides small, deterministic DataFrames covering the four data shapes
+the SDK supports — flat, flat-with-context, sequential, sequential-with-context —
+plus pre-built ``Encoder`` instances at each pipeline stage.
+
+All fixtures are function-scoped (the pytest default). DataFrames are
+mutable and ``Encoder`` is stateful, so a fresh instance per test prevents
+cross-test contamination at the cost of negligible setup time.
+"""
+
+import random
+from collections.abc import Iterator
+
+import pandas as pd
+import pytest
+import torch
+
+from dataxid.encoder import Encoder
+
+
+@pytest.fixture(autouse=True)
+def _isolate_torch_rng() -> Iterator[None]:
+    """Pin ``torch``'s global RNG to a fixed seed for each test.
+
+    ``Encoder`` initializes its model weights from the global generator,
+    so without isolation any test that constructs an encoder leaks state
+    into later tests, making reproductions of a single failure depend on
+    the order other tests ran in.
+    """
+    state = torch.random.get_rng_state()
+    torch.manual_seed(0)
+    try:
+        yield
+    finally:
+        torch.random.set_rng_state(state)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_python_rng() -> Iterator[None]:
+    """Snapshot and restore Python's ``random`` global state per test.
+
+    Several SDK paths (primary-key generation, sample shuffling) draw from
+    ``random``. Tests that call ``random.seed(...)`` would otherwise leak
+    the seeded sequence into every later test, making failures order-dependent.
+    """
+    state = random.getstate()
+    try:
+        yield
+    finally:
+        random.setstate(state)
+
+
+@pytest.fixture
+def sample_df() -> pd.DataFrame:
+    """Flat table — 8 rows with one numeric and one categorical column."""
+    return pd.DataFrame({
+        "age": [25, 30, 35, 40, 45, 50, 55, 60],
+        "city": ["A", "B", "A", "C", "B", "A", "C", "B"],
+    })
+
+
+@pytest.fixture
+def ctx_df() -> pd.DataFrame:
+    """Parent table for ``sample_df``, aligned 1:1 (one parent row per child row)."""
+    return pd.DataFrame({
+        "region": ["North", "South", "North", "East", "South", "North", "East", "South"],
+        "population": [100, 200, 100, 300, 200, 100, 300, 200],
+    })
+
+
+@pytest.fixture
+def seq_df() -> pd.DataFrame:
+    """
+    Sequential (1:N) child table — 3 entities with variable-length sequences (3, 2, 3 rows).
+
+    Foreign key ``account_id`` references the parent's primary key ``id``
+    (see :func:`seq_ctx_df`). The intentionally different column names
+    exercise the SDK's ``parent_key`` / ``foreign_key`` parameters.
+    """
+    return pd.DataFrame({
+        "account_id": [1, 1, 1, 2, 2, 3, 3, 3],
+        "amount": [100.0, 200.0, 150.0, 300.0, 250.0, 50.0, 75.0, 60.0],
+        "type": ["credit", "debit", "credit", "debit", "credit", "credit", "debit", "credit"],
+    })
+
+
+@pytest.fixture
+def seq_ctx_df() -> pd.DataFrame:
+    """Parent table for ``seq_df`` — one row per entity, primary key ``id``."""
+    return pd.DataFrame({
+        "id": [1, 2, 3],
+        "region": ["North", "South", "East"],
+    })
+
+
+@pytest.fixture
+def encoder() -> Encoder:
+    """Fresh ``Encoder`` with a minimal CPU config — fast enough for CI."""
+    return Encoder(embedding_dim=16, model_size="small", device="cpu")
+
+
+@pytest.fixture
+def analyzed_encoder(encoder: Encoder, sample_df: pd.DataFrame) -> Encoder:
+    """Encoder after :meth:`Encoder.analyze` — ready for ``prepare`` / ``encode``."""
+    encoder.analyze(sample_df)
+    return encoder
+
+
+@pytest.fixture
+def prepared_encoder(analyzed_encoder: Encoder, sample_df: pd.DataFrame) -> Encoder:
+    """
+    Encoder after ``analyze`` + ``prepare`` — ready for ``encode_batch`` / ``backward``.
+
+    ``sample_df`` is reused intentionally: ``prepare`` must run on the same
+    data that ``analyze`` observed.
+    """
+    analyzed_encoder.prepare(sample_df)
+    return analyzed_encoder

--- a/tests/sdk/test_async_polling.py
+++ b/tests/sdk/test_async_polling.py
@@ -1,0 +1,441 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the SDK's frozen-encoder training poll loop.
+
+The training endpoint is asynchronous: ``POST /train`` returns ``status:
+training`` immediately, after which the SDK long-polls ``GET /models/{id}``
+until the server reports ``status: ready`` or ``failed``. A legacy synchronous
+response (with ``epochs`` already populated) is still accepted for backward
+compatibility.
+
+Covered:
+
+* :func:`_poll_training` — interval backoff, timeout, status transitions.
+* :func:`_process_async_result` — metrics extraction from the final payload.
+* :func:`_process_sync_result` — backward-compat path with epoch history.
+* Per-epoch progress logging during long polls.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dataxid.exceptions import TrainingError, TrainingTimeoutError
+from dataxid.training._config import ModelConfig
+from dataxid.training._frozen import (
+    _POLL_INTERVALS,
+    _poll_training,
+    _process_async_result,
+    _process_sync_result,
+)
+from dataxid.training._model import Model
+
+_FROZEN_LOGGER = "dataxid.training._frozen"
+
+
+# ---------------------------------------------------------------------------
+# Helpers and fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_model(get_responses: list[dict[str, Any]] | None = None) -> Model:
+    """Build a :class:`Model` with a mocked HTTP client.
+
+    ``get_responses`` is consumed in order by successive ``client.get`` calls;
+    pass ``None`` (or omit) when the test does not exercise the polling loop.
+    """
+    client = MagicMock()
+    client.get = MagicMock(side_effect=list(get_responses or []))
+    client.post = MagicMock(return_value={"data": {"status": "training"}})
+
+    model = Model.__new__(Model)
+    model.id = "mdl_test123"
+    model._client = client
+    model._config = {}
+    model.status = "training"
+    model.train_losses = []
+    model.val_losses = []
+    model.stopped_early = False
+    return model
+
+
+@pytest.fixture()
+def mock_sleep(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Replace :func:`time.sleep` inside the polling module with a no-op."""
+    fake = MagicMock()
+    monkeypatch.setattr("dataxid.training._frozen.time.sleep", fake)
+    return fake
+
+
+@contextmanager
+def _capture_logs(logger_name: str) -> Iterator[list[logging.LogRecord]]:
+    """Attach a temporary handler to ``logger_name`` and yield its records.
+
+    Implemented directly (rather than via :func:`caplog`) so the assertion is
+    not affected by logger state set up elsewhere in the suite (handlers,
+    levels, ``disabled`` flags, ``propagate`` flags on parent loggers).
+    """
+    logger = logging.getLogger(logger_name)
+    records: list[logging.LogRecord] = []
+
+    handler = logging.Handler(level=logging.INFO)
+    handler.emit = records.append  # type: ignore[method-assign]
+
+    prev_level = logger.level
+    prev_disabled = logger.disabled
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.disabled = False
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prev_level)
+        logger.disabled = prev_disabled
+
+
+# ---------------------------------------------------------------------------
+# _poll_training — control flow
+# ---------------------------------------------------------------------------
+
+
+class TestPollTraining:
+    """Polling loop status transitions, timeout, and backoff."""
+
+    def test_polls_until_ready(self, mock_sleep: MagicMock) -> None:
+        responses = [
+            {"data": {"status": "training"}},
+            {"data": {"status": "training"}},
+            {
+                "data": {
+                    "status": "ready",
+                    "training_result": {
+                        "epochs": 10,
+                        "train_loss": 0.15,
+                        "val_loss": 0.18,
+                        "early_stopped": False,
+                        "duration_seconds": 5.2,
+                    },
+                }
+            },
+        ]
+        model = _make_model(responses)
+        _poll_training(model, timeout=60, max_epochs=10)
+
+        assert model.status == "ready"
+        assert model.stopped_early is False
+        assert model._client.get.call_count == 3
+
+    def test_raises_training_error_on_failed(self, mock_sleep: MagicMock) -> None:
+        responses = [
+            {"data": {"status": "training"}},
+            {"data": {"status": "failed", "error": "OOM on GPU worker"}},
+        ]
+        model = _make_model(responses)
+
+        with pytest.raises(TrainingError, match="OOM on GPU worker"):
+            _poll_training(model, timeout=60, max_epochs=10)
+
+    def test_raises_timeout_error(
+        self,
+        mock_sleep: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When elapsed time exceeds ``timeout`` the loop raises before the
+        next GET, surfacing the configured timeout in the error message."""
+        ticks = iter([0.0, 0.0, 100.0])
+        monkeypatch.setattr(
+            "dataxid.training._frozen.time.monotonic", lambda: next(ticks)
+        )
+        model = _make_model([{"data": {"status": "training"}}])
+
+        with pytest.raises(TrainingTimeoutError, match="10"):
+            _poll_training(model, timeout=10, max_epochs=100)
+
+    def test_backoff_uses_documented_intervals(self, mock_sleep: MagicMock) -> None:
+        """Sleep durations follow ``_POLL_INTERVALS`` in order."""
+        responses = [
+            {"data": {"status": "training"}},
+            {"data": {"status": "training"}},
+            {"data": {"status": "training"}},
+            {
+                "data": {
+                    "status": "ready",
+                    "training_result": {"epochs": 5, "train_loss": 0.1},
+                }
+            },
+        ]
+        model = _make_model(responses)
+        _poll_training(model, timeout=300, max_epochs=5)
+
+        sleep_calls = [c.args[0] for c in mock_sleep.call_args_list]
+        assert sleep_calls[:3] == _POLL_INTERVALS[:3]
+
+
+# ---------------------------------------------------------------------------
+# _poll_training — log output
+# ---------------------------------------------------------------------------
+
+
+class TestPollTrainingLogs:
+    """Per-poll log lines reflect server-reported epoch progress."""
+
+    def test_logs_per_epoch_progress_when_server_reports_it(
+        self, mock_sleep: MagicMock
+    ) -> None:
+        responses = [
+            {
+                "data": {
+                    "status": "training",
+                    "current_epoch": 2,
+                    "train_loss": 0.35,
+                    "val_loss": 0.40,
+                }
+            },
+            {
+                "data": {
+                    "status": "training",
+                    "current_epoch": 4,
+                    "train_loss": 0.20,
+                    "val_loss": 0.25,
+                }
+            },
+            {
+                "data": {
+                    "status": "ready",
+                    "current_epoch": 5,
+                    "train_loss": 0.15,
+                    "val_loss": 0.18,
+                    "training_result": {
+                        "epochs": 5,
+                        "train_loss": 0.15,
+                        "val_loss": 0.18,
+                    },
+                }
+            },
+        ]
+        model = _make_model(responses)
+
+        with _capture_logs(_FROZEN_LOGGER) as records:
+            _poll_training(model, timeout=60, max_epochs=5)
+
+        rendered = [r.getMessage() for r in records]
+        assert any("epoch=2/5" in m for m in rendered)
+        assert any("epoch=4/5" in m for m in rendered)
+
+    def test_logs_generic_status_when_server_omits_epoch(
+        self, mock_sleep: MagicMock
+    ) -> None:
+        responses = [
+            {"data": {"status": "training"}},
+            {
+                "data": {
+                    "status": "ready",
+                    "training_result": {"epochs": 3, "train_loss": 0.2},
+                }
+            },
+        ]
+        model = _make_model(responses)
+
+        with _capture_logs(_FROZEN_LOGGER) as records:
+            _poll_training(model, timeout=60, max_epochs=3)
+
+        rendered = [r.getMessage() for r in records]
+        assert any("Polling training" in m and "status=training" in m for m in rendered)
+
+
+# ---------------------------------------------------------------------------
+# _process_async_result
+# ---------------------------------------------------------------------------
+
+
+class TestProcessAsyncResult:
+    """Final-payload metrics extraction for the async path."""
+
+    def test_extracts_metrics(self) -> None:
+        model = _make_model()
+        result = {
+            "epochs": 42,
+            "train_loss": 0.123,
+            "val_loss": 0.156,
+            "early_stopped": True,
+            "duration_seconds": 120.5,
+        }
+        _process_async_result(model, result, max_epochs=100)
+
+        assert model.status == "ready"
+        assert model.stopped_early is True
+        assert model.train_losses == [0.123]
+        assert model.val_losses == [0.156]
+
+    def test_handles_missing_fields(self) -> None:
+        """An empty payload still leaves the model in a coherent ``ready``
+        state — no losses recorded, ``stopped_early`` defaulting to False."""
+        model = _make_model()
+        _process_async_result(model, {}, max_epochs=100)
+
+        assert model.status == "ready"
+        assert model.stopped_early is False
+        assert model.train_losses == []
+        assert model.val_losses == []
+
+
+# ---------------------------------------------------------------------------
+# _process_sync_result (backward compat)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessSyncResult:
+    """Legacy sync response path: per-epoch history is replayed in order."""
+
+    def test_processes_epoch_history(self) -> None:
+        model = _make_model()
+        data = {
+            "epochs": 3,
+            "train_loss": 0.2,
+            "val_loss": 0.25,
+            "early_stopped": False,
+            "epoch_history": [
+                {"epoch": 1, "train_loss": 0.5, "val_loss": 0.6, "learning_rate": 0.001},
+                {"epoch": 2, "train_loss": 0.3, "val_loss": 0.4, "learning_rate": 0.001},
+                {"epoch": 3, "train_loss": 0.2, "val_loss": 0.25, "learning_rate": 0.0005},
+            ],
+        }
+        _process_sync_result(model, data, max_epochs=10)
+
+        assert model.status == "ready"
+        assert model.train_losses == [0.5, 0.3, 0.2]
+        assert model.val_losses == [0.6, 0.4, 0.25]
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+
+class TestPollIntervals:
+    """``_POLL_INTERVALS`` is monotonically non-decreasing — required for the
+    intended exponential-style backoff. The matching default training timeout
+    on :class:`ModelConfig` is also pinned to guard against accidental edits."""
+
+    def test_intervals_monotonically_non_decreasing(self) -> None:
+        assert _POLL_INTERVALS == sorted(_POLL_INTERVALS)
+        assert all(v > 0 for v in _POLL_INTERVALS)
+
+    def test_default_timeout_matches_session_config(self) -> None:
+        assert ModelConfig().timeout == 14400.0
+
+
+# ---------------------------------------------------------------------------
+# Backoff and pacing invariants
+# ---------------------------------------------------------------------------
+
+
+class TestPollBackoffInvariants:
+    """Pacing contracts the loop must keep regardless of training duration."""
+
+    def test_backoff_clamps_to_last_interval_for_long_polls(
+        self, mock_sleep: MagicMock
+    ) -> None:
+        """Once the index walks past ``_POLL_INTERVALS``, the loop must reuse
+        the last value indefinitely — not raise :class:`IndexError`."""
+        n_polls = len(_POLL_INTERVALS) + 4
+        responses = [{"data": {"status": "training"}}] * n_polls + [
+            {
+                "data": {
+                    "status": "ready",
+                    "training_result": {"epochs": 1, "train_loss": 0.1},
+                }
+            }
+        ]
+        model = _make_model(responses)
+        _poll_training(model, timeout=10000, max_epochs=1)
+
+        sleep_calls = [c.args[0] for c in mock_sleep.call_args_list]
+        assert sleep_calls[: len(_POLL_INTERVALS)] == _POLL_INTERVALS
+        # Every poll past the table reuses the last interval — the plateau.
+        # Five extra sleeps: 4 "training" responses + 1 before the final
+        # "ready" GET (the loop sleeps before every GET, including the last).
+        assert sleep_calls[len(_POLL_INTERVALS) :] == [_POLL_INTERVALS[-1]] * 5
+
+    def test_sleeps_at_least_once_before_first_get(
+        self, mock_sleep: MagicMock
+    ) -> None:
+        """Even when the very first poll returns ``ready``, the loop sleeps
+        once so the SDK doesn't spam the server with back-to-back requests
+        immediately after ``POST /train``."""
+        responses = [
+            {
+                "data": {
+                    "status": "ready",
+                    "training_result": {"epochs": 1, "train_loss": 0.1},
+                }
+            }
+        ]
+        model = _make_model(responses)
+        _poll_training(model, timeout=60, max_epochs=1)
+
+        assert mock_sleep.call_count == 1
+        assert mock_sleep.call_args_list[0].args[0] == _POLL_INTERVALS[0]
+
+
+# ---------------------------------------------------------------------------
+# None-vs-value semantics in result extraction
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncResultLossSemantics:
+    """``None`` (missing) and concrete float values are kept distinct.
+
+    The previous implementation conflated ``None`` and ``0.0`` via
+    ``or 0`` + truthy filtering, silently dropping legitimate zero losses.
+    These tests pin the corrected ``is not None`` semantics so the regression
+    cannot return.
+    """
+
+    def test_zero_loss_is_recorded(self) -> None:
+        """A reported ``train_loss=0.0`` is a legitimate measurement (perfect
+        fit, single-class debug runs) and must reach ``model.train_losses``."""
+        model = _make_model()
+        _process_async_result(
+            model,
+            {"epochs": 5, "train_loss": 0.0, "val_loss": 0.0},
+            max_epochs=10,
+        )
+        assert model.train_losses == [0.0]
+        assert model.val_losses == [0.0]
+
+    def test_missing_loss_is_skipped(self) -> None:
+        """Absent / ``None`` losses leave the lists empty — the model stays
+        in a coherent ``ready`` state without spurious zero entries."""
+        model = _make_model()
+        _process_async_result(
+            model,
+            {"epochs": 5, "train_loss": None, "val_loss": None},
+            max_epochs=10,
+        )
+        assert model.train_losses == []
+        assert model.val_losses == []
+        assert model.status == "ready"
+
+    def test_missing_loss_does_not_crash_log_formatting(self) -> None:
+        """The completion log must format missing losses safely (``n/a``);
+        an unguarded ``%.4f`` against ``None`` would raise :class:`TypeError`."""
+        model = _make_model()
+        with _capture_logs(_FROZEN_LOGGER) as records:
+            _process_async_result(
+                model,
+                {"epochs": 5, "train_loss": None, "val_loss": None},
+                max_epochs=10,
+            )
+        rendered = [r.getMessage() for r in records]
+        completion = next((m for m in rendered if "Training completed" in m), None)
+        assert completion is not None
+        assert "n/a" in completion

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -1,0 +1,645 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for :class:`dataxid.client.DataxidClient`.
+
+Covers, with mocked ``httpx.request``:
+  - API key / base URL resolution (explicit > module-level > env var)
+  - Auth, Idempotency-Key and User-Agent header injection
+  - Retry policy (status codes, timeout, connection error, max attempts)
+  - 204 No Content handling
+  - Structured error parsing into typed exceptions
+  - Exponential backoff with ``Retry-After`` precedence
+"""
+
+from __future__ import annotations
+
+import email.utils
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+import dataxid
+from dataxid.client._http import (
+    _BACKOFF_BASE,
+    _MAX_RETRIES,
+    _MAX_RETRY_AFTER_SECONDS,
+    DataxidClient,
+    _parse_retry_after,
+)
+from dataxid.exceptions import (
+    APIError,
+    AuthenticationError,
+    ConflictError,
+    InvalidRequestError,
+    NotFoundError,
+    RateLimitError,
+)
+
+
+def _mock_response(
+    status_code: int = 200,
+    json_data: dict | None = None,
+    headers: dict | None = None,
+) -> httpx.Response:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.headers = headers or {}
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def _isolated_client_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Isolate every test from ambient ``dataxid.api_key`` / ``dataxid.base_url``
+    state and from a developer's local ``DATAXID_API_KEY`` env var.
+
+    Without this fixture, results would silently depend on the host shell's
+    environment, defeating the purpose of unit tests.
+    """
+    monkeypatch.setattr(dataxid, "api_key", None)
+    monkeypatch.setattr(dataxid, "base_url", "https://api.dataxid.com")
+    monkeypatch.delenv("DATAXID_API_KEY", raising=False)
+
+
+@pytest.fixture
+def mock_request() -> Iterator[MagicMock]:
+    """Mock the underlying ``httpx.request`` so no real HTTP traffic occurs."""
+    with patch("dataxid.client._http.httpx.request") as request:
+        request.return_value = _mock_response(200, {"data": {}})
+        yield request
+
+
+@pytest.fixture
+def mock_sleep() -> Iterator[MagicMock]:
+    """Mock ``time.sleep`` so tests don't actually wait for backoff."""
+    with patch("dataxid.client._http.time.sleep") as sleep:
+        yield sleep
+
+
+@pytest.fixture
+def client() -> DataxidClient:
+    """A ``DataxidClient`` with a fixed test API key."""
+    return DataxidClient(api_key="dx_test_abc")
+
+
+class TestApiKeyResolution:
+    """Resolution order: explicit constructor arg > module-level > env var > error."""
+
+    def test_explicit_key_used(self) -> None:
+        client = DataxidClient(api_key="dx_test_explicit")
+        assert client.api_key == "dx_test_explicit"
+
+    def test_module_level_key_used(self) -> None:
+        dataxid.api_key = "dx_test_module"
+        client = DataxidClient()
+        assert client.api_key == "dx_test_module"
+
+    def test_explicit_overrides_module(self) -> None:
+        dataxid.api_key = "dx_test_module"
+        client = DataxidClient(api_key="dx_test_explicit")
+        assert client.api_key == "dx_test_explicit"
+
+    def test_no_key_raises_auth_error(self) -> None:
+        client = DataxidClient()
+        with pytest.raises(AuthenticationError, match="No API key"):
+            _ = client.api_key
+
+    def test_env_var_used_when_no_other_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DATAXID_API_KEY", "dx_test_env")
+        client = DataxidClient()
+        assert client.api_key == "dx_test_env"
+
+    def test_explicit_overrides_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DATAXID_API_KEY", "dx_test_env")
+        client = DataxidClient(api_key="dx_test_explicit")
+        assert client.api_key == "dx_test_explicit"
+
+    def test_module_level_overrides_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dataxid.api_key = "dx_test_module"
+        monkeypatch.setenv("DATAXID_API_KEY", "dx_test_env")
+        client = DataxidClient()
+        assert client.api_key == "dx_test_module"
+
+    def test_error_message_mentions_env_var(self) -> None:
+        client = DataxidClient()
+        with pytest.raises(AuthenticationError, match="DATAXID_API_KEY"):
+            _ = client.api_key
+
+
+class TestBaseUrlResolution:
+    """Base URL: explicit constructor arg > module-level."""
+
+    def test_explicit_url(self) -> None:
+        client = DataxidClient(base_url="https://api.dataxid.com")
+        assert client.base_url == "https://api.dataxid.com"
+
+    def test_module_level_url(self) -> None:
+        dataxid.base_url = "https://eu.api.dataxid.com"
+        client = DataxidClient()
+        assert client.base_url == "https://eu.api.dataxid.com"
+
+    def test_explicit_overrides_module(self) -> None:
+        dataxid.base_url = "https://eu.api.dataxid.com"
+        client = DataxidClient(base_url="https://api.dataxid.com")
+        assert client.base_url == "https://api.dataxid.com"
+
+
+class TestAuthHeader:
+    """Authorization and Content-Type headers are injected on every request."""
+
+    def test_bearer_token_sent(self, mock_request: MagicMock) -> None:
+        client = DataxidClient(api_key="dx_test_abc123")
+        client.get("/v1/models")
+
+        _, kwargs = mock_request.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer dx_test_abc123"
+
+    def test_content_type_json(
+        self, client: DataxidClient, mock_request: MagicMock,
+    ) -> None:
+        client.get("/v1/models")
+
+        _, kwargs = mock_request.call_args
+        assert kwargs["headers"]["Content-Type"] == "application/json"
+
+
+class TestIdempotencyKey:
+    """Idempotency-Key is added only to retryable POST requests."""
+
+    def test_post_includes_idempotency_key(
+        self, client: DataxidClient, mock_request: MagicMock,
+    ) -> None:
+        mock_request.return_value = _mock_response(201, {"data": {"id": "mdl_1"}})
+        client.post("/v1/models", json={"metadata": {}})
+
+        _, kwargs = mock_request.call_args
+        assert "Idempotency-Key" in kwargs["headers"]
+        assert len(kwargs["headers"]["Idempotency-Key"]) == 32  # uuid4 hex
+
+    def test_get_no_idempotency_key(
+        self, client: DataxidClient, mock_request: MagicMock,
+    ) -> None:
+        client.get("/v1/models")
+
+        _, kwargs = mock_request.call_args
+        assert "Idempotency-Key" not in kwargs["headers"]
+
+    def test_post_idempotent_false_no_key(
+        self, client: DataxidClient, mock_request: MagicMock,
+    ) -> None:
+        client.post("/v1/models/mdl_1/train-step", json={}, idempotent=False)
+
+        _, kwargs = mock_request.call_args
+        assert "Idempotency-Key" not in kwargs["headers"]
+
+    def test_unique_keys_per_call(
+        self, client: DataxidClient, mock_request: MagicMock,
+    ) -> None:
+        mock_request.return_value = _mock_response(201, {"data": {"id": "mdl_1"}})
+
+        client.post("/v1/models", json={})
+        key1 = mock_request.call_args[1]["headers"]["Idempotency-Key"]
+
+        client.post("/v1/models", json={})
+        key2 = mock_request.call_args[1]["headers"]["Idempotency-Key"]
+
+        assert key1 != key2
+
+
+class TestSuccessfulRequests:
+    """Happy path: 2xx responses are decoded as JSON; 204 returns ``None``."""
+
+    def test_get_returns_json(
+        self, client: DataxidClient, mock_request: MagicMock,
+    ) -> None:
+        mock_request.return_value = _mock_response(200, {"data": {"id": "mdl_1"}})
+        assert client.get("/v1/models/mdl_1") == {"data": {"id": "mdl_1"}}
+
+    def test_post_returns_json(
+        self, client: DataxidClient, mock_request: MagicMock,
+    ) -> None:
+        mock_request.return_value = _mock_response(201, {"data": {"id": "mdl_1"}})
+        assert client.post("/v1/models", json={"metadata": {}}) == {"data": {"id": "mdl_1"}}
+
+    def test_delete_returns_none(
+        self, client: DataxidClient, mock_request: MagicMock,
+    ) -> None:
+        mock_request.return_value = _mock_response(204)
+        assert client.delete("/v1/models/mdl_1") is None
+
+    def test_url_construction(self, mock_request: MagicMock) -> None:
+        client = DataxidClient(api_key="dx_test_abc", base_url="https://api.dataxid.com")
+        client.get("/v1/models")
+
+        _, kwargs = mock_request.call_args
+        assert kwargs["url"] == "https://api.dataxid.com/v1/models"
+
+    def test_url_construction_with_trailing_slash_in_base(
+        self, mock_request: MagicMock,
+    ) -> None:
+        """A trailing slash in ``base_url`` must not produce a double slash."""
+        client = DataxidClient(
+            api_key="dx_test_abc", base_url="https://api.dataxid.com/",
+        )
+        client.get("/v1/models")
+
+        _, kwargs = mock_request.call_args
+        assert kwargs["url"] == "https://api.dataxid.com/v1/models"
+
+
+class TestRetryLogic:
+    """Retry policy: transient failures are retried up to ``_MAX_RETRIES``."""
+
+    def test_retries_on_500(
+        self, client: DataxidClient, mock_request: MagicMock, mock_sleep: MagicMock,
+    ) -> None:
+        mock_request.side_effect = [
+            _mock_response(500, {"error": {"type": "api_error", "message": "fail"}}),
+            _mock_response(200, {"data": {"ok": True}}),
+        ]
+
+        assert client.get("/v1/models") == {"data": {"ok": True}}
+        assert mock_request.call_count == 2
+
+    def test_retries_on_502(
+        self, client: DataxidClient, mock_request: MagicMock, mock_sleep: MagicMock,
+    ) -> None:
+        mock_request.side_effect = [
+            _mock_response(502, {"error": {"type": "api_error", "message": "bad gw"}}),
+            _mock_response(200, {"data": {}}),
+        ]
+
+        client.get("/v1/models")
+        assert mock_request.call_count == 2
+
+    def test_retries_on_429(
+        self, client: DataxidClient, mock_request: MagicMock, mock_sleep: MagicMock,
+    ) -> None:
+        """429 is retried (rate-limit recovers); only the final attempt surfaces."""
+        mock_request.side_effect = [
+            _mock_response(
+                429, {"error": {"type": "rate_limit_error", "message": "slow down"}},
+            ),
+            _mock_response(200, {"data": {}}),
+        ]
+
+        client.get("/v1/models")
+        assert mock_request.call_count == 2
+
+    def test_retries_on_timeout(
+        self, client: DataxidClient, mock_request: MagicMock, mock_sleep: MagicMock,
+    ) -> None:
+        mock_request.side_effect = [
+            httpx.TimeoutException("timeout"),
+            _mock_response(200, {"data": {}}),
+        ]
+
+        assert client.get("/v1/models") == {"data": {}}
+        assert mock_request.call_count == 2
+
+    def test_retries_on_connect_error(
+        self, client: DataxidClient, mock_request: MagicMock, mock_sleep: MagicMock,
+    ) -> None:
+        mock_request.side_effect = [
+            httpx.ConnectError("refused"),
+            _mock_response(200, {"data": {}}),
+        ]
+
+        assert client.get("/v1/models") == {"data": {}}
+        assert mock_request.call_count == 2
+
+    def test_raises_after_max_retries_timeout(
+        self, client: DataxidClient, mock_request: MagicMock, mock_sleep: MagicMock,
+    ) -> None:
+        mock_request.side_effect = httpx.TimeoutException("timeout")
+
+        with pytest.raises(APIError, match="timed out"):
+            client.get("/v1/models")
+        assert mock_request.call_count == _MAX_RETRIES
+
+    def test_raises_after_max_retries_connect(
+        self, client: DataxidClient, mock_request: MagicMock, mock_sleep: MagicMock,
+    ) -> None:
+        mock_request.side_effect = httpx.ConnectError("refused")
+
+        with pytest.raises(APIError, match="Connection failed"):
+            client.get("/v1/models")
+        assert mock_request.call_count == _MAX_RETRIES
+
+    def test_raises_after_max_retries_500(
+        self, client: DataxidClient, mock_request: MagicMock, mock_sleep: MagicMock,
+    ) -> None:
+        mock_request.return_value = _mock_response(
+            500, {"error": {"type": "api_error", "message": "internal"}},
+        )
+
+        with pytest.raises(APIError):
+            client.get("/v1/models")
+        assert mock_request.call_count == _MAX_RETRIES
+
+    def test_no_retry_on_400(
+        self, client: DataxidClient, mock_request: MagicMock,
+    ) -> None:
+        mock_request.return_value = _mock_response(
+            400, {"error": {"type": "invalid_request_error", "message": "bad"}},
+        )
+
+        with pytest.raises(InvalidRequestError):
+            client.post("/v1/models", json={})
+        assert mock_request.call_count == 1
+
+    def test_no_retry_on_401(
+        self, client: DataxidClient, mock_request: MagicMock,
+    ) -> None:
+        mock_request.return_value = _mock_response(
+            401, {"error": {"type": "authentication_error", "message": "bad key"}},
+        )
+
+        with pytest.raises(AuthenticationError):
+            client.get("/v1/models")
+        assert mock_request.call_count == 1
+
+    def test_no_retry_on_404(
+        self, client: DataxidClient, mock_request: MagicMock,
+    ) -> None:
+        mock_request.return_value = _mock_response(
+            404, {"error": {"type": "not_found_error", "message": "not found"}},
+        )
+
+        with pytest.raises(NotFoundError):
+            client.get("/v1/models/mdl_x")
+        assert mock_request.call_count == 1
+
+
+class TestErrorParsing:
+    """``_parse_error`` maps the HTTP response body into the right exception type."""
+
+    def test_400_invalid_request(self) -> None:
+        resp = _mock_response(400, {
+            "error": {"type": "invalid_request_error", "message": "bad param", "param": "metadata"},
+        })
+        exc = DataxidClient._parse_error(resp)
+        assert isinstance(exc, InvalidRequestError)
+        assert exc.param == "metadata"
+        assert exc.status_code == 400
+
+    def test_401_authentication(self) -> None:
+        resp = _mock_response(401, {
+            "error": {"type": "authentication_error", "message": "invalid key"},
+        })
+        exc = DataxidClient._parse_error(resp)
+        assert isinstance(exc, AuthenticationError)
+        assert exc.status_code == 401
+
+    def test_404_not_found(self) -> None:
+        resp = _mock_response(404, {
+            "error": {"type": "not_found_error", "message": "model not found"},
+        })
+        exc = DataxidClient._parse_error(resp)
+        assert isinstance(exc, NotFoundError)
+        assert exc.status_code == 404
+
+    def test_409_conflict(self) -> None:
+        resp = _mock_response(409, {
+            "error": {"type": "api_error", "message": "conflict"},
+        })
+        exc = DataxidClient._parse_error(resp)
+        assert isinstance(exc, ConflictError)
+        assert exc.status_code == 409
+
+    def test_429_rate_limit(self) -> None:
+        resp = _mock_response(
+            429,
+            {"error": {"type": "rate_limit_error", "message": "slow down"}},
+            headers={"Retry-After": "30"},
+        )
+        exc = DataxidClient._parse_error(resp)
+        assert isinstance(exc, RateLimitError)
+        assert exc.retry_after == 30.0
+        assert exc.status_code == 429
+
+    def test_429_no_retry_after(self) -> None:
+        resp = _mock_response(429, {
+            "error": {"type": "rate_limit_error", "message": "slow down"},
+        })
+        exc = DataxidClient._parse_error(resp)
+        assert isinstance(exc, RateLimitError)
+        assert exc.retry_after is None
+
+    def test_429_unparseable_retry_after_falls_back_to_none(self) -> None:
+        """A garbage ``Retry-After`` must not crash error parsing."""
+        resp = _mock_response(
+            429,
+            {"error": {"type": "rate_limit_error", "message": "slow down"}},
+            headers={"Retry-After": "soon-ish"},
+        )
+        exc = DataxidClient._parse_error(resp)
+        assert isinstance(exc, RateLimitError)
+        assert exc.retry_after is None
+
+    def test_500_api_error(self) -> None:
+        resp = _mock_response(500, {
+            "error": {"type": "api_error", "message": "internal"},
+        })
+        exc = DataxidClient._parse_error(resp)
+        assert isinstance(exc, APIError)
+        assert exc.status_code == 500
+
+    def test_unknown_type_falls_back_to_api_error(self) -> None:
+        resp = _mock_response(500, {
+            "error": {"type": "unknown_error_type", "message": "weird"},
+        })
+        exc = DataxidClient._parse_error(resp)
+        assert isinstance(exc, APIError)
+
+    def test_non_json_response(self) -> None:
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 502
+        resp.json.side_effect = ValueError("not json")
+        resp.headers = {}
+        exc = DataxidClient._parse_error(resp)
+        assert isinstance(exc, APIError)
+        assert "502" in str(exc)
+
+    def test_request_id_captured(self) -> None:
+        resp = _mock_response(
+            400,
+            {"error": {"type": "invalid_request_error", "message": "bad"}},
+            headers={"X-Request-Id": "req_abc123"},
+        )
+        exc = DataxidClient._parse_error(resp)
+        assert exc.request_id == "req_abc123"
+
+    def test_missing_request_id(self) -> None:
+        resp = _mock_response(400, {
+            "error": {"type": "invalid_request_error", "message": "bad"},
+        })
+        exc = DataxidClient._parse_error(resp)
+        assert exc.request_id is None
+
+
+class TestRetryAfterParsing:
+    """``_parse_retry_after`` accepts both RFC 9110 forms and clamps degenerate values."""
+
+    def test_integer_seconds(self) -> None:
+        assert _parse_retry_after("30") == 30.0
+
+    def test_fractional_seconds_accepted(self) -> None:
+        assert _parse_retry_after("1.5") == 1.5
+
+    def test_whitespace_is_tolerated(self) -> None:
+        assert _parse_retry_after("  30  ") == 30.0
+
+    def test_none_and_empty_return_none(self) -> None:
+        assert _parse_retry_after(None) is None
+        assert _parse_retry_after("") is None
+        assert _parse_retry_after("   ") is None
+
+    def test_garbage_returns_none(self) -> None:
+        assert _parse_retry_after("soon-ish") is None
+
+    def test_negative_seconds_return_none(self) -> None:
+        assert _parse_retry_after("-5") is None
+
+    def test_seconds_clamped_to_max(self) -> None:
+        assert _parse_retry_after("1000000") == _MAX_RETRY_AFTER_SECONDS
+
+    def test_http_date_in_future_returns_seconds(self) -> None:
+        future = datetime.now(tz=timezone.utc) + timedelta(seconds=120)
+        header = email.utils.format_datetime(future, usegmt=True)
+
+        result = _parse_retry_after(header)
+
+        assert result is not None
+        assert 110.0 <= result <= 120.0  # allow a few seconds for test scheduling
+
+    def test_http_date_in_past_returns_none(self) -> None:
+        past = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        header = email.utils.format_datetime(past, usegmt=True)
+        assert _parse_retry_after(header) is None
+
+    def test_http_date_far_future_clamped(self) -> None:
+        far_future = datetime.now(tz=timezone.utc) + timedelta(days=365)
+        header = email.utils.format_datetime(far_future, usegmt=True)
+        assert _parse_retry_after(header) == _MAX_RETRY_AFTER_SECONDS
+
+
+class TestUserAgent:
+    """Every request advertises ``dataxid-python/{version}``."""
+
+    def test_user_agent_sent(
+        self, client: DataxidClient, mock_request: MagicMock,
+    ) -> None:
+        client.get("/v1/models")
+
+        _, kwargs = mock_request.call_args
+        assert kwargs["headers"]["User-Agent"] == f"dataxid-python/{dataxid.__version__}"
+
+
+class TestTimeout:
+    """Default: ``connect=10s`` (fail fast on unreachable), ``read=300s`` (patient on training)."""
+
+    def test_default_timeout_is_httpx_timeout(
+        self, client: DataxidClient, mock_request: MagicMock,
+    ) -> None:
+        client.get("/v1/models")
+
+        _, kwargs = mock_request.call_args
+        timeout = kwargs["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.connect == 10.0
+        assert timeout.read == 300.0
+
+    def test_custom_timeout_override(self, mock_request: MagicMock) -> None:
+        custom = httpx.Timeout(connect=5.0, read=60.0, write=60.0, pool=5.0)
+        client = DataxidClient(api_key="dx_test_abc", timeout=custom)
+        client.get("/v1/models")
+
+        _, kwargs = mock_request.call_args
+        assert kwargs["timeout"].connect == 5.0
+        assert kwargs["timeout"].read == 60.0
+
+
+class TestBackoff:
+    """Exponential backoff between retries; ``Retry-After`` takes precedence."""
+
+    def test_backoff_called_on_retry(
+        self, client: DataxidClient, mock_request: MagicMock, mock_sleep: MagicMock,
+    ) -> None:
+        mock_request.side_effect = [
+            _mock_response(500, {"error": {"type": "api_error", "message": "fail"}}),
+            _mock_response(200, {"data": {}}),
+        ]
+
+        client.get("/v1/models")
+
+        assert mock_sleep.call_count == 1
+        delay = mock_sleep.call_args[0][0]
+        assert delay >= _BACKOFF_BASE  # base + jitter
+
+    def test_backoff_increases_with_attempts(
+        self, client: DataxidClient, mock_request: MagicMock, mock_sleep: MagicMock,
+    ) -> None:
+        error = _mock_response(500, {"error": {"type": "api_error", "message": "fail"}})
+        mock_request.side_effect = [error, error, error]
+
+        with pytest.raises(APIError):
+            client.get("/v1/models")
+
+        assert mock_sleep.call_count == 2
+        delay_0 = mock_sleep.call_args_list[0][0][0]
+        delay_1 = mock_sleep.call_args_list[1][0][0]
+        assert delay_1 > delay_0
+
+    def test_retry_after_header_respected(
+        self, client: DataxidClient, mock_request: MagicMock, mock_sleep: MagicMock,
+    ) -> None:
+        mock_request.side_effect = [
+            _mock_response(
+                429,
+                {"error": {"type": "rate_limit_error", "message": "slow down"}},
+                headers={"Retry-After": "5"},
+            ),
+            _mock_response(200, {"data": {}}),
+        ]
+
+        client.get("/v1/models")
+
+        delay = mock_sleep.call_args[0][0]
+        # ``Retry-After=5`` plus up to 25% jitter (see ``_sleep_before_retry``).
+        assert 5.0 <= delay <= 5.0 * 1.25
+
+    def test_backoff_on_timeout_exception(
+        self, client: DataxidClient, mock_request: MagicMock, mock_sleep: MagicMock,
+    ) -> None:
+        mock_request.side_effect = [
+            httpx.TimeoutException("timeout"),
+            _mock_response(200, {"data": {}}),
+        ]
+
+        client.get("/v1/models")
+        assert mock_sleep.call_count == 1
+
+    def test_no_backoff_on_non_retryable(
+        self, client: DataxidClient, mock_request: MagicMock, mock_sleep: MagicMock,
+    ) -> None:
+        mock_request.return_value = _mock_response(
+            400, {"error": {"type": "invalid_request_error", "message": "bad"}},
+        )
+
+        with pytest.raises(InvalidRequestError):
+            client.post("/v1/models", json={})
+
+        mock_sleep.assert_not_called()
+
+
+class TestDefaultBaseUrl:
+    """The shipped default base URL points at production."""
+
+    def test_default_is_production(self) -> None:
+        assert dataxid.base_url == "https://api.dataxid.com"

--- a/tests/sdk/test_decode.py
+++ b/tests/sdk/test_decode.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the client-side decode pipeline (``dataxid.pipeline._decode``).
+
+The decode stage maps integer codes produced by the server back into real
+feature values using per-column statistics held only on the client side.
+
+Coverage focuses on two contracts that are easy to break and costly to ship:
+
+1. ``rare_strategy`` controls whether the ``<protected>`` sentinel is replaced
+   by a frequent draw (``"sample"``, default) or kept literally (``"mask"``).
+2. Numeric decode paths must never let the sentinel leak into a numeric dtype,
+   regardless of the strategy — otherwise the sentinel would be coerced to NA
+   and silently mask a type-pollution bug.
+
+Coverage of other encoding types (continuous, datetime, lat/long, character)
+lives in the pipeline-level test suite; this module is intentionally scoped to
+the client-visible ``rare_strategy`` knob and the ``decode_columns`` dispatcher.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from dataxid.encoder._ports import EncodingType, wire_key
+from dataxid.pipeline._decode import (
+    _decode_categorical,
+    _decode_numeric_discrete,
+    decode_columns,
+)
+from dataxid.pipeline._transform import NULL_TOKEN, RARE_TOKEN
+
+
+@pytest.fixture(autouse=True)
+def _isolate_numpy_rng() -> Iterator[None]:
+    """Pin ``numpy.random`` to a fixed seed per test and restore on exit.
+
+    The decode pipeline still uses the legacy global RNG, so two tests run
+    back-to-back can otherwise observe each other's draws. Snapshotting the
+    state and resetting it makes assertions on stochastic output reproducible
+    without leaking determinism across the rest of the suite.
+    """
+    state = np.random.get_state()
+    np.random.seed(0)
+    try:
+        yield
+    finally:
+        np.random.set_state(state)
+
+
+@pytest.fixture
+def categorical_stats() -> dict:
+    """Vocabulary with both sentinels and three frequent categories.
+
+    Layout: ``0=<<NULL>>``, ``1=<protected>``, ``2=A``, ``3=B``, ``4=C``.
+    """
+    return {
+        "codes": {NULL_TOKEN: 0, RARE_TOKEN: 1, "A": 2, "B": 3, "C": 4},
+        "encoding_type": EncodingType.categorical,
+        "no_of_rare_categories": 3,
+    }
+
+
+@pytest.fixture
+def numeric_discrete_stats() -> dict:
+    """Numeric discrete column without ``NULL_TOKEN`` in its vocabulary.
+
+    Layout: ``0=<protected>``, ``1=1``, ``2=2``, ``3=3``. Because no NULL
+    sentinel is registered, rare codes are resolved by sampling a frequent
+    value rather than collapsing to NA — the path most production columns hit.
+    """
+    return {
+        "codes": {RARE_TOKEN: 0, "1": 1, "2": 2, "3": 3},
+        "encoding_type": EncodingType.numeric_discrete,
+        "min_decimal": 0,
+    }
+
+
+class TestDecodeCategoricalSample:
+    """Default mode — rare codes are replaced by frequent draws."""
+
+    def test_no_rare_passthrough(self, categorical_stats: dict) -> None:
+        codes = np.array([2, 3, 4, 2])
+        result = _decode_categorical(codes, categorical_stats)
+        assert list(result) == ["A", "B", "C", "A"]
+
+    def test_rare_replaced_not_literal(self, categorical_stats: dict) -> None:
+        codes = np.array([1, 1, 1, 1, 1])
+        result = _decode_categorical(codes, categorical_stats)
+        assert RARE_TOKEN not in set(result.dropna())
+        assert set(result.dropna()).issubset({"A", "B", "C"})
+
+    def test_null_still_becomes_na(self, categorical_stats: dict) -> None:
+        codes = np.array([0, 2])
+        result = _decode_categorical(codes, categorical_stats)
+        assert pd.isna(result.iloc[0])
+        assert result.iloc[1] == "A"
+
+
+class TestDecodeCategoricalMask:
+    """Mask mode — rare codes surface as the literal ``<protected>`` token."""
+
+    def test_mask_preserves_rare_null_and_frequent(
+        self, categorical_stats: dict
+    ) -> None:
+        codes = np.array([0, 1, 2, 1, 3])
+        result = _decode_categorical(
+            codes, categorical_stats, rare_strategy="mask"
+        )
+        assert pd.isna(result.iloc[0])
+        assert result.iloc[1] == RARE_TOKEN
+        assert result.iloc[2] == "A"
+        assert result.iloc[3] == RARE_TOKEN
+        assert result.iloc[4] == "B"
+
+
+class TestDecodeCategoricalEdgeCases:
+    """Boundary conditions where the rare-replacement path has no fallback."""
+
+    def test_sample_falls_back_to_na_when_no_frequent_categories(
+        self,
+    ) -> None:
+        """If the vocabulary contains only sentinels, sampled rare codes
+        cannot be replaced by a real value and must collapse to NA rather
+        than echo the literal ``<protected>`` token."""
+        stats = {
+            "codes": {NULL_TOKEN: 0, RARE_TOKEN: 1},
+            "encoding_type": EncodingType.categorical,
+            "no_of_rare_categories": 1,
+        }
+        codes = np.array([1, 1, 0])
+        result = _decode_categorical(codes, stats)
+        assert result.isna().all()
+
+
+class TestDecodeNumericDiscrete:
+    """Numeric columns must never leak ``<protected>`` into numeric output."""
+
+    def test_rare_never_appears_in_output(
+        self, numeric_discrete_stats: dict
+    ) -> None:
+        codes = np.array([0, 1, 0, 2])
+        result = _decode_numeric_discrete(codes, numeric_discrete_stats)
+        assert result.dtype.name == "Int64"
+        for v in result.dropna():
+            assert v in {1, 2, 3}
+
+    def test_frequent_passthrough(
+        self, numeric_discrete_stats: dict
+    ) -> None:
+        codes = np.array([1, 2, 3, 1])
+        result = _decode_numeric_discrete(codes, numeric_discrete_stats)
+        assert list(result) == [1, 2, 3, 1]
+
+    def test_rare_collapses_to_na_when_null_token_in_vocabulary(
+        self,
+    ) -> None:
+        """When ``NULL_TOKEN`` is part of the vocabulary, the discrete
+        decoder treats rare codes as missing instead of resampling — the
+        opposite branch of the resampling test above."""
+        stats = {
+            "codes": {NULL_TOKEN: 0, RARE_TOKEN: 1, "1": 2, "2": 3},
+            "encoding_type": EncodingType.numeric_discrete,
+            "min_decimal": 0,
+        }
+        codes = np.array([0, 1, 2, 1, 3])
+        result = _decode_numeric_discrete(codes, stats)
+        assert result.dtype.name == "Int64"
+        assert pd.isna(result.iloc[0])
+        assert pd.isna(result.iloc[1])
+        assert result.iloc[2] == 1
+        assert pd.isna(result.iloc[3])
+        assert result.iloc[4] == 2
+
+
+class TestDecodeColumnsModeForwarding:
+    def _make_raw(self, feature: str, codes: list[int]) -> dict:
+        return {wire_key(feature, "cat"): codes}
+
+    def test_returns_only_requested_columns_in_order(
+        self, categorical_stats: dict, numeric_discrete_stats: dict
+    ) -> None:
+        """Dispatcher contract: output frame holds exactly the requested
+        feature names, in the requested order, regardless of the input
+        ``raw_codes`` ordering."""
+        raw = {
+            wire_key("num", "cat"): [1, 2, 3],
+            wire_key("cat", "cat"): [2, 3, 4],
+        }
+        stats = {"cat": categorical_stats, "num": numeric_discrete_stats}
+        df = decode_columns(raw, ["cat", "num"], stats)
+        assert list(df.columns) == ["cat", "num"]
+        assert len(df) == 3
+
+    def test_mask_mode_keeps_rare(self, categorical_stats: dict) -> None:
+        raw = self._make_raw("cat", [1, 2, 1])
+        df = decode_columns(
+            raw,
+            ["cat"],
+            {"cat": categorical_stats},
+            rare_strategy="mask",
+        )
+        assert list(df["cat"]) == [RARE_TOKEN, "A", RARE_TOKEN]
+
+    def test_mask_mode_does_not_leak_into_numeric(
+        self, numeric_discrete_stats: dict
+    ) -> None:
+        """Mask mode must not bypass the numeric dtype guard."""
+        raw = {wire_key("num", "cat"): [0, 1, 2, 3]}
+        df = decode_columns(
+            raw,
+            ["num"],
+            {"num": numeric_discrete_stats},
+            rare_strategy="mask",
+        )
+        assert df["num"].dtype.name == "Int64"
+        for v in df["num"].dropna():
+            assert v in {1, 2, 3}

--- a/tests/sdk/test_encoder.py
+++ b/tests/sdk/test_encoder.py
@@ -1,0 +1,840 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for :class:`dataxid.encoder.Encoder`, the SDK's client-side encoder.
+
+The encoder owns the analyze → prepare → encode pipeline that turns raw
+DataFrames into the wire payload sent to the API. Tests are organized by
+public surface and data shape:
+
+- ``analyze`` / ``prepare`` / ``encode_batch`` / ``_generation_embedding``
+  contracts on flat, contextual, and sequential data.
+- State machine: methods refuse to run before their prerequisites.
+- ``protect_rare`` toggle and the ``wire_key`` helper.
+
+Tests that intentionally depend on private state (underscore-prefixed
+attributes, ``_encode_batches``, ``_nn`` constants) live in
+``TestInternalContracts`` so the tradeoff is visible.
+"""
+
+import json
+
+import pandas as pd
+import pytest
+import torch
+
+from dataxid.client._serialization import ENCODING_NUMPY_B64, deserialize_embedding
+from dataxid.encoder import Encoder
+from dataxid.encoder._nn import SIDX_PREFIX
+from dataxid.encoder._ports import (
+    WIRE_COLUMN_SEP,
+    WIRE_PREFIX,
+    WIRE_SUB_COLUMN_SEP,
+    WIRE_TABLE_SEP,
+    wire_key,
+)
+from dataxid.exceptions import ModelNotReadyError
+
+
+class TestAnalyze:
+    """``Encoder.analyze()`` — raw data to API metadata."""
+
+    def test_contains_required_keys(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        meta = encoder.analyze(sample_df)
+        required = {
+            "cardinalities",
+            "features",
+            "column_stats",
+            "value_mappings",
+            "empirical_probs",
+        }
+        assert required.issubset(meta.keys())
+
+    def test_features_match_columns(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        meta = encoder.analyze(sample_df)
+        assert meta["features"] == list(sample_df.columns)
+
+    def test_cardinalities_are_positive_ints(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        meta = encoder.analyze(sample_df)
+        for card in meta["cardinalities"].values():
+            assert isinstance(card, int)
+            assert card > 0
+
+    def test_empirical_probs_are_lists(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        meta = encoder.analyze(sample_df)
+        for probs in meta["empirical_probs"].values():
+            assert isinstance(probs, list)
+            assert all(isinstance(p, float) for p in probs)
+
+    def test_empirical_probs_sum_near_one(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        meta = encoder.analyze(sample_df)
+        for probs in meta["empirical_probs"].values():
+            assert abs(sum(probs) - 1.0) < 0.05
+
+    def test_column_stats_has_entries(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        meta = encoder.analyze(sample_df)
+        assert len(meta["column_stats"]) > 0
+
+    def test_metadata_is_json_serializable(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        meta = encoder.analyze(sample_df)
+        assert len(json.dumps(meta)) > 0
+
+    def test_is_deterministic_for_same_input(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        """Two analyze() calls on the same DataFrame must produce identical
+        metadata so downstream training and decoding are reproducible."""
+        first = encoder.analyze(sample_df)
+        second = encoder.analyze(sample_df)
+        assert first["features"] == second["features"]
+        assert first["cardinalities"] == second["cardinalities"]
+        assert first["column_stats"] == second["column_stats"]
+        assert first["empirical_probs"] == second["empirical_probs"]
+
+
+class TestPrepare:
+    """``Encoder.prepare()`` — pre-encode data into tensors."""
+
+    def test_succeeds_after_analyze(
+        self, analyzed_encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        analyzed_encoder.prepare(sample_df)
+
+    def test_fails_before_analyze(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        with pytest.raises(ModelNotReadyError):
+            encoder.prepare(sample_df)
+
+
+class TestEncodeBatch:
+    """``Encoder.encode_batch()`` produces a wire payload + targets + id."""
+
+    def test_returns_tuple(self, prepared_encoder: Encoder) -> None:
+        embedding, targets, eid = prepared_encoder.encode_batch()
+        assert isinstance(embedding, dict)
+        assert isinstance(targets, dict)
+        assert isinstance(eid, int)
+
+    def test_embedding_is_binary_payload(
+        self, prepared_encoder: Encoder
+    ) -> None:
+        embedding, _, _ = prepared_encoder.encode_batch()
+        assert embedding["encoding"] == ENCODING_NUMPY_B64
+        assert embedding["dtype"] == "float32"
+        assert "embedding_b64" in embedding
+        assert "shape" in embedding
+
+    def test_embedding_shape(
+        self, prepared_encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        embedding, _, _ = prepared_encoder.encode_batch()
+        assert embedding["shape"][0] == len(sample_df)
+        assert embedding["shape"][1] == 16
+
+    def test_targets_have_entries(self, prepared_encoder: Encoder) -> None:
+        _, targets, _ = prepared_encoder.encode_batch()
+        assert len(targets) > 0
+
+    def test_targets_values_are_int_lists(
+        self, prepared_encoder: Encoder
+    ) -> None:
+        _, targets, _ = prepared_encoder.encode_batch()
+        for values in targets.values():
+            assert isinstance(values, list)
+            assert all(isinstance(v, int) for v in values)
+
+    def test_batch_with_indices(self, prepared_encoder: Encoder) -> None:
+        embedding, _, _ = prepared_encoder.encode_batch(indices=[0, 1, 2])
+        assert embedding["shape"][0] == 3
+
+    def test_batch_with_empty_indices_returns_empty_payload(
+        self, prepared_encoder: Encoder
+    ) -> None:
+        """``indices=[]`` must round-trip as an empty batch — no crash, full
+        payload structure preserved — so callers can build batches safely
+        from filtered index sets without special-casing the empty result."""
+        embedding, targets, _ = prepared_encoder.encode_batch(indices=[])
+        assert embedding["shape"][0] == 0
+        assert embedding["shape"][1] == 16
+        assert embedding["encoding"] == ENCODING_NUMPY_B64
+        for values in targets.values():
+            assert values == []
+
+    def test_embed_id_increments(self, prepared_encoder: Encoder) -> None:
+        _, _, eid1 = prepared_encoder.encode_batch()
+        _, _, eid2 = prepared_encoder.encode_batch()
+        assert eid2 == eid1 + 1
+
+    def test_fails_before_prepare(
+        self, analyzed_encoder: Encoder
+    ) -> None:
+        with pytest.raises(RuntimeError, match="prepare"):
+            analyzed_encoder.encode_batch()
+
+    def test_fails_before_analyze(self, encoder: Encoder) -> None:
+        with pytest.raises(ModelNotReadyError):
+            encoder.encode_batch()
+
+    def test_json_serializable(self, prepared_encoder: Encoder) -> None:
+        embedding, targets, _ = prepared_encoder.encode_batch()
+        json.dumps({"embedding": embedding, "targets": targets})
+
+
+class TestGenerationEmbedding:
+    """``Encoder._generation_embedding()`` — context-conditioned embedding."""
+
+    def test_returns_binary_payload(
+        self, analyzed_encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        result = analyzed_encoder._generation_embedding(
+            n_samples=len(sample_df)
+        )
+        assert isinstance(result, dict)
+        assert result["encoding"] == ENCODING_NUMPY_B64
+
+    def test_zero_embedding_by_default(
+        self, analyzed_encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        """Default path emits a zero embedding for classifier-free guidance."""
+        result = analyzed_encoder._generation_embedding(
+            n_samples=len(sample_df)
+        )
+        assert result["shape"] == [len(sample_df), 16]
+        emb = deserialize_embedding(result)
+        assert torch.all(emb == 0)
+
+    def test_conditions_produces_real_embedding(
+        self, analyzed_encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        """Passing conditions switches to conditional generation."""
+        result = analyzed_encoder._generation_embedding(
+            n_samples=len(sample_df), conditions=sample_df,
+        )
+        assert result["shape"] == [len(sample_df), 16]
+        emb = deserialize_embedding(result)
+        assert not torch.all(emb == 0)
+
+    def test_fails_before_analyze(self, encoder: Encoder) -> None:
+        with pytest.raises(ModelNotReadyError):
+            encoder._generation_embedding(n_samples=10)
+
+    def test_json_serializable(self, analyzed_encoder: Encoder) -> None:
+        result = analyzed_encoder._generation_embedding(n_samples=5)
+        json.dumps(result)
+
+    def test_zero_n_samples_returns_empty_payload(
+        self, analyzed_encoder: Encoder
+    ) -> None:
+        """Generating zero samples must return an empty embedding rather
+        than raise, so callers can drive generation from arbitrary loop
+        sizes without guarding against the zero case."""
+        result = analyzed_encoder._generation_embedding(n_samples=0)
+        assert result["shape"] == [0, 16]
+        assert result["encoding"] == ENCODING_NUMPY_B64
+
+
+class TestStateMachine:
+    """Encoder enforces ``analyze`` → ``prepare`` → ``encode`` ordering."""
+
+    def test_fresh_encoder_rejects_prepare(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        with pytest.raises(ModelNotReadyError):
+            encoder.prepare(sample_df)
+
+    def test_fresh_encoder_rejects_encode_batch(
+        self, encoder: Encoder
+    ) -> None:
+        with pytest.raises(ModelNotReadyError):
+            encoder.encode_batch()
+
+    def test_fresh_encoder_rejects_generation_embedding(
+        self, encoder: Encoder
+    ) -> None:
+        with pytest.raises(ModelNotReadyError):
+            encoder._generation_embedding(n_samples=10)
+
+    def test_analyzed_encoder_rejects_encode_batch(
+        self, analyzed_encoder: Encoder
+    ) -> None:
+        with pytest.raises(RuntimeError, match="prepare"):
+            analyzed_encoder.encode_batch()
+
+    def test_full_flow(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        meta = encoder.analyze(sample_df)
+        assert "features" in meta
+
+        encoder.prepare(sample_df)
+        embedding, _, _ = encoder.encode_batch()
+        assert embedding["shape"][0] == len(sample_df)
+
+        gen_emb = encoder._generation_embedding(n_samples=len(sample_df))
+        assert gen_emb["shape"][0] == len(sample_df)
+
+
+class TestContextAnalyze:
+    """``Encoder.analyze(parent=)`` — parent-table metadata merging."""
+
+    def test_has_context_flag_set(
+        self,
+        encoder: Encoder,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+    ) -> None:
+        meta = encoder.analyze(sample_df, parent=ctx_df)
+        assert meta["has_context"] is True
+
+    def test_has_context_flag_false_without_ctx(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        meta = encoder.analyze(sample_df)
+        assert meta["has_context"] is False
+
+    def test_cardinalities_exclude_context_keys(
+        self,
+        encoder: Encoder,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+    ) -> None:
+        meta = encoder.analyze(sample_df, parent=ctx_df)
+        target_only = encoder.analyze(sample_df)
+        assert len(meta["cardinalities"]) == len(target_only["cardinalities"])
+
+    def test_empirical_probs_exclude_context(
+        self,
+        encoder: Encoder,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+    ) -> None:
+        meta = encoder.analyze(sample_df, parent=ctx_df)
+        target_only = encoder.analyze(sample_df)
+        assert len(meta["empirical_probs"]) == len(
+            target_only["empirical_probs"]
+        )
+
+    def test_features_are_target_only(
+        self,
+        encoder: Encoder,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+    ) -> None:
+        meta = encoder.analyze(sample_df, parent=ctx_df)
+        assert meta["features"] == list(sample_df.columns)
+
+    def test_metadata_is_json_serializable(
+        self,
+        encoder: Encoder,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+    ) -> None:
+        meta = encoder.analyze(sample_df, parent=ctx_df)
+        json.dumps(meta)
+
+
+class TestContextPrepareAndEncode:
+    """``prepare(parent=)`` + ``encode_batch()`` with context tensors."""
+
+    def test_prepare_with_context(
+        self,
+        encoder: Encoder,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+    ) -> None:
+        encoder.analyze(sample_df, parent=ctx_df)
+        encoder.prepare(sample_df, parent=ctx_df)
+        assert encoder.has_context is True
+
+    def test_encode_batch_with_context_shape(
+        self,
+        encoder: Encoder,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+    ) -> None:
+        encoder.analyze(sample_df, parent=ctx_df)
+        encoder.prepare(sample_df, parent=ctx_df)
+        embedding, _, _ = encoder.encode_batch()
+        assert embedding["shape"][0] == len(sample_df)
+        assert embedding["shape"][1] == 16
+
+    def test_encode_batch_indices_with_context(
+        self,
+        encoder: Encoder,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+    ) -> None:
+        encoder.analyze(sample_df, parent=ctx_df)
+        encoder.prepare(sample_df, parent=ctx_df)
+        embedding, _, _ = encoder.encode_batch(indices=[0, 1, 2])
+        assert embedding["shape"][0] == 3
+
+    def test_generation_embedding_with_context(
+        self,
+        encoder: Encoder,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+    ) -> None:
+        encoder.analyze(sample_df, parent=ctx_df)
+        result = encoder._generation_embedding(
+            n_samples=len(sample_df), conditions=sample_df, parent=ctx_df,
+        )
+        assert result["shape"] == [len(sample_df), 16]
+        emb = deserialize_embedding(result)
+        assert not torch.all(emb == 0)
+
+
+class TestBackwardCompatEncoder:
+    """Context-free calls must keep the pre-context behavior."""
+
+    def test_analyze_without_context_unchanged(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        meta = encoder.analyze(sample_df)
+        assert meta["has_context"] is False
+        assert "cardinalities" in meta
+        assert meta["features"] == list(sample_df.columns)
+
+    def test_prepare_without_context_unchanged(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        encoder.analyze(sample_df)
+        encoder.prepare(sample_df)
+        assert encoder.has_context is False
+
+    def test_encode_batch_without_context_unchanged(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        encoder.analyze(sample_df)
+        encoder.prepare(sample_df)
+        embedding, _, _ = encoder.encode_batch()
+        assert embedding["shape"] == [len(sample_df), 16]
+
+
+class TestSequentialAnalyze:
+    """``Encoder.analyze(foreign_key=)`` — sequential mode detection."""
+
+    def test_sequential_detected(
+        self,
+        encoder: Encoder,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+    ) -> None:
+        meta = encoder.analyze(
+            seq_df, parent=seq_ctx_df,
+            foreign_key="account_id", parent_key="id",
+        )
+        assert meta["is_sequential"] is True
+
+    def test_seq_len_params(
+        self,
+        encoder: Encoder,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+    ) -> None:
+        meta = encoder.analyze(
+            seq_df, parent=seq_ctx_df,
+            foreign_key="account_id", parent_key="id",
+        )
+        assert meta["seq_len_max"] == 3
+        assert meta["seq_len_median"] == 3
+
+    def test_features_exclude_foreign_key(
+        self,
+        encoder: Encoder,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+    ) -> None:
+        meta = encoder.analyze(
+            seq_df, parent=seq_ctx_df,
+            foreign_key="account_id", parent_key="id",
+        )
+        assert "account_id" not in meta["features"]
+
+    def test_has_context_true(
+        self,
+        encoder: Encoder,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+    ) -> None:
+        meta = encoder.analyze(
+            seq_df, parent=seq_ctx_df,
+            foreign_key="account_id", parent_key="id",
+        )
+        assert meta["has_context"] is True
+
+    def test_not_sequential_without_key(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        meta = encoder.analyze(sample_df)
+        assert meta["is_sequential"] is False
+        assert meta["seq_len_max"] == 1
+
+
+class TestSequentialPrepare:
+    """``prepare()`` in sequential mode — entity-level tensor padding."""
+
+    def test_prepare_sequential(
+        self,
+        encoder: Encoder,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+    ) -> None:
+        encoder.analyze(
+            seq_df, parent=seq_ctx_df,
+            foreign_key="account_id", parent_key="id",
+        )
+        encoder.prepare(seq_df, parent=seq_ctx_df, parent_key="id")
+        assert encoder.is_sequential is True
+
+
+class TestSequentialGenerationEmbedding:
+    """``_generation_embedding()`` in sequential mode."""
+
+    def test_returns_embedding(
+        self,
+        encoder: Encoder,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+    ) -> None:
+        encoder.analyze(
+            seq_df, parent=seq_ctx_df,
+            foreign_key="account_id", parent_key="id",
+        )
+        result = encoder._generation_embedding(n_samples=3, parent=seq_ctx_df)
+        assert isinstance(result, dict)
+        assert result["shape"][0] == 3
+
+    def test_zero_embedding_without_ctx(
+        self,
+        encoder: Encoder,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+    ) -> None:
+        encoder.analyze(
+            seq_df, parent=seq_ctx_df,
+            foreign_key="account_id", parent_key="id",
+        )
+        result = encoder._generation_embedding(n_samples=5)
+        assert result["shape"][0] == 5
+        emb = deserialize_embedding(result)
+        assert torch.all(emb == 0)
+
+    def test_ctx_embedding_not_zero(
+        self,
+        encoder: Encoder,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+    ) -> None:
+        encoder.analyze(
+            seq_df, parent=seq_ctx_df,
+            foreign_key="account_id", parent_key="id",
+        )
+        result = encoder._generation_embedding(n_samples=3, parent=seq_ctx_df)
+        emb = deserialize_embedding(result)
+        assert not torch.all(emb == 0)
+
+
+class TestBackwardCompatSequential:
+    """Sequential additions must not affect flat-mode behavior."""
+
+    def test_flat_analyze_unchanged(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        meta = encoder.analyze(sample_df)
+        assert meta["is_sequential"] is False
+        assert meta["seq_len_max"] == 1
+        assert meta["seq_len_median"] == 1
+
+    def test_flat_encode_unchanged(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        encoder.analyze(sample_df)
+        encoder.prepare(sample_df)
+        embedding, _, _ = encoder.encode_batch()
+        assert embedding["shape"] == [len(sample_df), 16]
+
+
+class TestProtectRare:
+    """``Encoder(protect_rare=...)`` — rare-category suppression toggle."""
+
+    @staticmethod
+    def _make_encoder(protect_rare: bool) -> Encoder:
+        return Encoder(
+            embedding_dim=16,
+            model_size="small",
+            device="cpu",
+            protect_rare=protect_rare,
+        )
+
+    @staticmethod
+    def _rare_df() -> pd.DataFrame:
+        """Four frequent categories plus one rare label that triggers protection."""
+        return pd.DataFrame({
+            "cat": ["A"] * 50 + ["B"] * 50 + ["C"] * 50 + ["D"] * 50
+                   + ["Z_rare"] * 2,
+        })
+
+    def test_default_is_true(self) -> None:
+        assert Encoder().protect_rare_enabled
+
+    def test_protection_on_replaces_rare_with_token(self) -> None:
+        enc = self._make_encoder(protect_rare=True)
+        enc.analyze(self._rare_df())
+        codes = enc.column_stats["cat"]["codes"]
+        assert "Z_rare" not in codes
+        assert "<protected>" in codes
+
+    def test_protection_off_preserves_rare_value(self) -> None:
+        enc = self._make_encoder(protect_rare=False)
+        enc.analyze(self._rare_df())
+        codes = enc.column_stats["cat"]["codes"]
+        assert "Z_rare" in codes
+        assert enc.column_stats["cat"].get("no_of_rare_categories", 0) == 0
+
+
+class TestWireKey:
+    """``wire_key()`` — feature/sub-column → wire identifier."""
+
+    def test_format(self) -> None:
+        assert wire_key("age", "cat") == "feat:/age__cat"
+
+    def test_uses_constants(self) -> None:
+        expected = (
+            f"{WIRE_PREFIX}{WIRE_TABLE_SEP}{WIRE_COLUMN_SEP}col"
+            f"{WIRE_SUB_COLUMN_SEP}sub"
+        )
+        assert wire_key("col", "sub") == expected
+
+    def test_special_chars_in_feature(self) -> None:
+        assert wire_key("first_name", "char_0") == "feat:/first_name__char_0"
+
+
+class TestInternalContracts:
+    """Tests that intentionally depend on private state.
+
+    These exist because the public surface does not yet expose enough hooks
+    to assert the underlying invariant. They guard against regressions in
+    code paths that have no observable proxy today (e.g. the internal batch
+    builder, the rare-category constructor flag, and the positional index
+    cardinalities used by the sequential model).
+
+    When the corresponding public attribute or method is added, the matching
+    test should be moved out of this class and rewritten against it.
+    """
+
+    def test_freeze_disables_grad_on_all_backend_parameters(
+        self, prepared_encoder: Encoder
+    ) -> None:
+        """Frozen-encoder training mode must not propagate gradients into the
+        encoder, otherwise the API would have to round-trip weight updates."""
+        prepared_encoder.freeze()
+        assert all(not p.requires_grad for p in prepared_encoder._backend.parameters())
+
+    def test_freeze_before_analyze_raises(self) -> None:
+        with pytest.raises(ModelNotReadyError, match="analyze"):
+            Encoder(embedding_dim=16, model_size="small").freeze()
+
+    def test_encode_batches_partitions_rows_into_train_and_validation(
+        self, prepared_encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        """Every row appears exactly once across train+val with the expected
+        per-batch split (``batch_size=4``, ``val_split=0.25`` → 6 train rows
+        in two batches, 2 validation rows in one batch)."""
+        prepared_encoder.freeze()
+        batches = prepared_encoder._encode_batches(
+            batch_size=4, val_split=0.25
+        )
+
+        train = [b for b in batches if not b["is_validation"]]
+        val = [b for b in batches if b["is_validation"]]
+
+        assert len(train) == 2
+        assert len(val) == 1
+
+        train_rows = sum(b["embedding"]["shape"][0] for b in train)
+        val_rows = sum(b["embedding"]["shape"][0] for b in val)
+        assert train_rows + val_rows == len(sample_df)
+        assert val_rows == 2
+
+        for b in batches:
+            assert "embedding" in b
+            assert "targets" in b
+
+    def test_encode_batches_clears_live_embeddings_after_serialization(
+        self, prepared_encoder: Encoder
+    ) -> None:
+        """``_encode_batches`` must release every staged tensor so a long
+        training run does not leak GPU memory across epochs."""
+        prepared_encoder.freeze()
+        prepared_encoder._encode_batches(batch_size=4, val_split=0.25)
+        assert prepared_encoder._live_embeddings == {}
+
+    def test_encode_batches_before_prepare_raises(
+        self, analyzed_encoder: Encoder
+    ) -> None:
+        analyzed_encoder.freeze()
+        with pytest.raises(RuntimeError, match="prepare"):
+            analyzed_encoder._encode_batches()
+
+    def test_encode_batches_with_context_produces_train_and_validation(
+        self,
+        encoder: Encoder,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+    ) -> None:
+        encoder.analyze(sample_df, parent=ctx_df)
+        encoder.prepare(sample_df, parent=ctx_df)
+        encoder.freeze()
+        encoder.eval_mode()
+        batches = encoder._encode_batches(batch_size=4)
+        train = [b for b in batches if not b["is_validation"]]
+        val = [b for b in batches if b["is_validation"]]
+        assert len(train) >= 1
+        assert len(val) == 1
+
+    def test_encode_batches_marks_sequential_flag(
+        self,
+        encoder: Encoder,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+    ) -> None:
+        encoder.analyze(
+            seq_df, parent=seq_ctx_df,
+            foreign_key="account_id", parent_key="id",
+        )
+        encoder.prepare(seq_df, parent=seq_ctx_df, parent_key="id")
+        encoder.freeze()
+        encoder.eval_mode()
+        batches = encoder._encode_batches(batch_size=4)
+        train_batches = [b for b in batches if not b.get("is_validation")]
+        assert train_batches[0].get("is_sequential") is True
+
+    def test_seq_data_populated_after_sequential_prepare(
+        self,
+        encoder: Encoder,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+    ) -> None:
+        encoder.analyze(
+            seq_df, parent=seq_ctx_df,
+            foreign_key="account_id", parent_key="id",
+        )
+        encoder.prepare(seq_df, parent=seq_ctx_df, parent_key="id")
+        first_key = next(iter(encoder._seq_data))
+        assert len(encoder._seq_data[first_key]) == 3
+
+    def test_positional_cardinalities_present_in_sequential_meta(
+        self,
+        encoder: Encoder,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+    ) -> None:
+        meta = encoder.analyze(
+            seq_df, parent=seq_ctx_df,
+            foreign_key="account_id", parent_key="id",
+        )
+        sidx_keys = [
+            k for k in meta["cardinalities"] if k.startswith(SIDX_PREFIX)
+        ]
+        assert len(sidx_keys) == 1
+
+    def test_apply_gradient_accumulates_without_stepping(
+        self, prepared_encoder: Encoder
+    ) -> None:
+        """``_apply_gradient`` is the frozen-training hook: it stores gradients
+        on the backend parameters but must never call ``optimizer.step()`` —
+        otherwise the encoder would silently drift between API calls."""
+        params_before = [p.clone() for p in prepared_encoder._backend.parameters()]
+        n_rows = len(prepared_encoder._tensors[next(iter(prepared_encoder._tensors))])
+        _, _, eid = prepared_encoder.encode_batch(list(range(n_rows)))
+        grad = torch.randn(n_rows, prepared_encoder._embedding_dim)
+
+        prepared_encoder._apply_gradient(grad, embed_id=eid)
+
+        for before, after in zip(
+            params_before, prepared_encoder._backend.parameters(), strict=True
+        ):
+            assert torch.equal(before, after), (
+                "_apply_gradient must accumulate gradients only, never step"
+            )
+        assert any(
+            p.grad is not None and p.grad.any()
+            for p in prepared_encoder._backend.parameters()
+        )
+
+    def test_step_after_apply_gradient_updates_weights(
+        self, prepared_encoder: Encoder
+    ) -> None:
+        """The companion test: ``step()`` *does* commit the accumulated gradient."""
+        prepared_encoder.zero_grad()
+        n_rows = len(prepared_encoder._tensors[next(iter(prepared_encoder._tensors))])
+        _, _, eid = prepared_encoder.encode_batch(list(range(n_rows)))
+        grad = torch.randn(n_rows, prepared_encoder._embedding_dim)
+        params_before = [p.clone() for p in prepared_encoder._backend.parameters()]
+
+        prepared_encoder._apply_gradient(grad, embed_id=eid)
+        prepared_encoder.step()
+
+        assert any(
+            not torch.equal(before, after)
+            for before, after in zip(
+                params_before, prepared_encoder._backend.parameters(), strict=True
+            )
+        )
+
+    def test_apply_gradient_with_subset_indices(
+        self, prepared_encoder: Encoder
+    ) -> None:
+        """Subset batches (e.g. validation slices) must accept gradients of the
+        matching length without index errors."""
+        indices = [0, 2, 4]
+        prepared_encoder.zero_grad()
+        _, _, eid = prepared_encoder.encode_batch(indices)
+        grad = torch.randn(len(indices), prepared_encoder._embedding_dim)
+        params_before = [p.clone() for p in prepared_encoder._backend.parameters()]
+
+        prepared_encoder._apply_gradient(grad, embed_id=eid)
+        prepared_encoder.step()
+
+        assert any(
+            not torch.equal(before, after)
+            for before, after in zip(
+                params_before, prepared_encoder._backend.parameters(), strict=True
+            )
+        )
+
+    def test_discard_embedding_removes_from_live_set(
+        self, prepared_encoder: Encoder
+    ) -> None:
+        """``_discard_embedding`` is the cleanup hook called after each batch."""
+        n_rows = len(prepared_encoder._tensors[next(iter(prepared_encoder._tensors))])
+        _, _, eid = prepared_encoder.encode_batch(list(range(n_rows)))
+        assert eid in prepared_encoder._live_embeddings
+
+        prepared_encoder._discard_embedding(eid)
+
+        assert eid not in prepared_encoder._live_embeddings
+
+    def test_apply_gradient_without_live_embedding_raises(
+        self, prepared_encoder: Encoder
+    ) -> None:
+        with pytest.raises(RuntimeError, match="No live embedding"):
+            prepared_encoder._apply_gradient(
+                torch.randn(4, prepared_encoder._embedding_dim), embed_id=999
+            )

--- a/tests/sdk/test_exceptions.py
+++ b/tests/sdk/test_exceptions.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the SDK exception hierarchy.
+
+The hierarchy is part of the SDK's public contract: callers rely on
+``except DataxidError`` to catch every error the SDK raises, and on the
+typed ``status_code`` / ``request_id`` / ``param`` / ``retry_after`` /
+``usage`` / ``upgrade_url`` attributes to make programmatic decisions.
+
+Tests are organized by responsibility: hierarchy invariants, base-class
+attributes, per-subclass extensions, top-level package re-exports, and
+pickle round-trip safety (so exceptions survive async/multiprocess
+boundaries without losing their typed attributes).
+"""
+
+import pickle
+
+import pytest
+
+import dataxid
+from dataxid.exceptions import (
+    APIError,
+    AuthenticationError,
+    ConflictError,
+    DataxidError,
+    InvalidRequestError,
+    ModelNotReadyError,
+    NotFoundError,
+    QuotaExceededError,
+    RateLimitError,
+    TrainingError,
+    TrainingTimeoutError,
+)
+
+_ALL_SUBCLASSES = [
+    AuthenticationError,
+    InvalidRequestError,
+    NotFoundError,
+    RateLimitError,
+    QuotaExceededError,
+    ConflictError,
+    ModelNotReadyError,
+    TrainingError,
+    TrainingTimeoutError,
+    APIError,
+]
+
+
+class TestHierarchy:
+    """Every SDK exception is a ``DataxidError`` so callers can catch one."""
+
+    @pytest.mark.parametrize("exc_class", _ALL_SUBCLASSES)
+    def test_subclass_can_be_caught_as_dataxid_error(
+        self, exc_class: type[DataxidError]
+    ) -> None:
+        with pytest.raises(DataxidError):
+            raise exc_class("test")
+
+    def test_dataxid_error_is_a_python_exception(self) -> None:
+        assert issubclass(DataxidError, Exception)
+
+
+class TestBaseAttributes:
+    """``DataxidError`` carries ``message``, ``status_code``, ``request_id``."""
+
+    def test_str_returns_constructor_message(self) -> None:
+        assert str(DataxidError("something went wrong")) == "something went wrong"
+
+    def test_status_code_is_stored_when_provided(self) -> None:
+        exc = DataxidError("fail", status_code=500)
+        assert exc.status_code == 500
+
+    def test_request_id_is_stored_when_provided(self) -> None:
+        exc = DataxidError("fail", request_id="req_abc123")
+        assert exc.request_id == "req_abc123"
+
+    def test_optional_attributes_default_to_none(self) -> None:
+        exc = DataxidError("fail")
+        assert exc.status_code is None
+        assert exc.request_id is None
+
+    def test_all_attributes_can_be_set_together(self) -> None:
+        exc = DataxidError("fail", status_code=400, request_id="req_xyz")
+        assert str(exc) == "fail"
+        assert exc.status_code == 400
+        assert exc.request_id == "req_xyz"
+
+
+class TestInvalidRequestError:
+    """``InvalidRequestError.param`` points at the offending field."""
+
+    def test_param_is_stored_when_provided(self) -> None:
+        exc = InvalidRequestError("bad field", param="metadata.features")
+        assert exc.param == "metadata.features"
+
+    def test_param_defaults_to_none(self) -> None:
+        assert InvalidRequestError("bad request").param is None
+
+    def test_inherits_base_attributes(self) -> None:
+        exc = InvalidRequestError(
+            "bad", param="x", status_code=400, request_id="req_1"
+        )
+        assert exc.status_code == 400
+        assert exc.request_id == "req_1"
+        assert exc.param == "x"
+        assert str(exc) == "bad"
+
+
+class TestRateLimitError:
+    """``RateLimitError.retry_after`` carries the server's back-off hint."""
+
+    def test_retry_after_is_stored_when_provided(self) -> None:
+        assert RateLimitError("slow down", retry_after=30.0).retry_after == 30.0
+
+    def test_retry_after_defaults_to_none(self) -> None:
+        assert RateLimitError("slow down").retry_after is None
+
+    def test_inherits_base_attributes(self) -> None:
+        exc = RateLimitError(
+            "limit", retry_after=60.0, status_code=429, request_id="req_2"
+        )
+        assert exc.status_code == 429
+        assert exc.request_id == "req_2"
+        assert exc.retry_after == 60.0
+        assert str(exc) == "limit"
+
+
+class TestQuotaExceededError:
+    """``QuotaExceededError`` exposes ``usage`` and ``upgrade_url`` for UIs."""
+
+    def test_usage_is_stored_when_provided(self) -> None:
+        usage = {"models_trained": 10, "limit": 5}
+        assert QuotaExceededError("over quota", usage=usage).usage == usage
+
+    def test_upgrade_url_is_stored_when_provided(self) -> None:
+        url = "https://example.test/upgrade"
+        assert QuotaExceededError("over quota", upgrade_url=url).upgrade_url == url
+
+    def test_optional_attributes_default_to_none(self) -> None:
+        exc = QuotaExceededError("over quota")
+        assert exc.usage is None
+        assert exc.upgrade_url is None
+
+    def test_inherits_base_attributes(self) -> None:
+        exc = QuotaExceededError(
+            "over quota",
+            usage={"x": 1},
+            upgrade_url="https://u",
+            status_code=402,
+            request_id="req_q",
+        )
+        assert exc.status_code == 402
+        assert exc.request_id == "req_q"
+        assert exc.usage == {"x": 1}
+        assert exc.upgrade_url == "https://u"
+        assert str(exc) == "over quota"
+
+
+class TestTopLevelImport:
+    """Every exception is re-exported from the ``dataxid`` package root."""
+
+    @pytest.mark.parametrize(
+        "exc_class", [DataxidError, *_ALL_SUBCLASSES]
+    )
+    def test_reexported_at_package_root(
+        self, exc_class: type[DataxidError]
+    ) -> None:
+        assert getattr(dataxid, exc_class.__name__) is exc_class
+
+    def test_no_unexposed_exception_subclasses(self) -> None:
+        """Catch the case where a new ``*Error`` is added to ``exceptions``
+        but forgotten in ``dataxid/__init__.py`` re-exports."""
+        from dataxid import exceptions as exc_mod
+        defined_in_module = {
+            name for name, obj in vars(exc_mod).items()
+            if isinstance(obj, type)
+            and issubclass(obj, DataxidError)
+            and obj.__module__ == exc_mod.__name__
+        }
+        missing = {n for n in defined_in_module if not hasattr(dataxid, n)}
+        assert missing == set(), f"Missing top-level re-exports: {missing}"
+
+
+class TestPickleRoundTrip:
+    """Exceptions must survive pickle so they cross process boundaries.
+
+    SDK exceptions travel through ``concurrent.futures``, ``multiprocessing``,
+    Celery workers, and similar transports that pickle their arguments.
+    Losing a typed attribute en route would silently downgrade a typed error
+    into a generic one at the call site, so every public exception is
+    exercised round-trip with a fully-populated payload.
+    """
+
+    @pytest.mark.parametrize("exc_class", _ALL_SUBCLASSES)
+    def test_base_attributes_survive_pickle(
+        self, exc_class: type[DataxidError]
+    ) -> None:
+        original = exc_class("boom", status_code=500, request_id="req_p")
+        restored = pickle.loads(pickle.dumps(original))
+        assert type(restored) is exc_class
+        assert str(restored) == "boom"
+        assert restored.status_code == 500
+        assert restored.request_id == "req_p"
+
+    def test_invalid_request_param_survives_pickle(self) -> None:
+        original = InvalidRequestError(
+            "bad", param="features", status_code=400, request_id="req_p"
+        )
+        restored = pickle.loads(pickle.dumps(original))
+        assert restored.param == "features"
+        assert restored.status_code == 400
+
+    def test_rate_limit_retry_after_survives_pickle(self) -> None:
+        original = RateLimitError(
+            "slow", retry_after=12.5, status_code=429, request_id="req_p"
+        )
+        restored = pickle.loads(pickle.dumps(original))
+        assert restored.retry_after == 12.5
+        assert restored.status_code == 429
+
+    def test_quota_exceeded_payload_survives_pickle(self) -> None:
+        original = QuotaExceededError(
+            "over",
+            usage={"models": 10},
+            upgrade_url="https://u",
+            status_code=402,
+            request_id="req_p",
+        )
+        restored = pickle.loads(pickle.dumps(original))
+        assert restored.usage == {"models": 10}
+        assert restored.upgrade_url == "https://u"
+        assert restored.status_code == 402

--- a/tests/sdk/test_exceptions.py
+++ b/tests/sdk/test_exceptions.py
@@ -107,6 +107,48 @@ class TestInvalidRequestError:
         assert str(exc) == "bad"
 
 
+class TestInvalidRequestErrorContract:
+    """``InvalidRequestError`` multi-inherits from ``DataxidError`` and
+    ``ValueError`` so callers can use either ``except DataxidError`` for
+    SDK-wide handling or the Python-idiomatic ``except ValueError`` for
+    validation failures.
+    """
+
+    def test_is_a_dataxid_error(self) -> None:
+        assert issubclass(InvalidRequestError, DataxidError)
+
+    def test_is_a_value_error(self) -> None:
+        """Multi-inheritance from ``ValueError`` keeps ``except ValueError``
+        working for callers writing Python-idiomatic validation handlers."""
+        assert issubclass(InvalidRequestError, ValueError)
+
+    def test_can_be_caught_as_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            raise InvalidRequestError("bad", param="x")
+
+    def test_can_be_caught_as_dataxid_error(self) -> None:
+        with pytest.raises(DataxidError):
+            raise InvalidRequestError("bad", param="x")
+
+    def test_domain_object_rejection_is_an_invalid_request_error(self) -> None:
+        """Domain object constructors (Bias, Synthetic, Distribution,
+        Privacy) raise ``InvalidRequestError`` with a populated ``param``
+        — the SDK's single contract for "bad caller input"."""
+        from dataxid import Bias
+
+        with pytest.raises(InvalidRequestError) as exc_info:
+            Bias(target="", sensitive=["g"])
+        assert exc_info.value.param == "target"
+
+    def test_domain_object_rejection_is_still_a_value_error(self) -> None:
+        """Backwards-compatibility: callers using ``except ValueError``
+        continue to catch validation failures from domain constructors."""
+        from dataxid import Bias
+
+        with pytest.raises(ValueError):
+            Bias(target="", sensitive=["g"])
+
+
 class TestRateLimitError:
     """``RateLimitError.retry_after`` carries the server's back-off hint."""
 

--- a/tests/sdk/test_logging.py
+++ b/tests/sdk/test_logging.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the SDK logging surface.
+
+The ``dataxid`` logger is opt-in: importing the package leaves the logger
+silent (``NullHandler`` only) so the SDK never spams a host application's
+log stream by accident. Tests cover the public ``enable_logging`` /
+``disable_logging`` toggle, the ``DATAXID_LOG`` environment hook, and the
+``SensitiveHeadersFilter`` that masks API credentials before they reach
+any log sink.
+"""
+
+import logging
+from typing import Any
+
+import pytest
+
+import dataxid
+from dataxid._log import SensitiveHeadersFilter, logger, setup_logging
+
+
+@pytest.fixture(autouse=True)
+def _clean_logger() -> None:
+    """Reset the package logger before and after each test.
+
+    The ``dataxid`` logger is module-level global state, so without explicit
+    isolation a test that calls ``enable_logging`` would leak handlers and
+    filters into every test that ran afterwards.
+    """
+    dataxid.disable_logging()
+    logger.handlers = [logging.NullHandler()]
+    yield
+    dataxid.disable_logging()
+    logger.handlers = [logging.NullHandler()]
+
+
+def _make_record(args: Any) -> logging.LogRecord:
+    record = logging.LogRecord("test", logging.INFO, "", 0, "msg", (), None)
+    record.args = args
+    return record
+
+
+def _stream_handlers() -> list[logging.Handler]:
+    return [
+        h for h in logger.handlers
+        if isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.NullHandler)
+    ]
+
+
+class TestEnableLogging:
+    """``enable_logging`` attaches a ``StreamHandler`` and credential filter."""
+
+    def test_sets_level(self) -> None:
+        dataxid.enable_logging("debug")
+        assert logger.level == logging.DEBUG
+
+    def test_level_is_case_insensitive(self) -> None:
+        dataxid.enable_logging("WARNING")
+        assert logger.level == logging.WARNING
+
+    def test_attaches_sensitive_headers_filter(self) -> None:
+        dataxid.enable_logging("info")
+        assert any(
+            isinstance(f, SensitiveHeadersFilter) for f in logger.filters
+        )
+
+    def test_idempotent_does_not_duplicate_handlers_or_filters(self) -> None:
+        """Repeated calls update the level but never stack handlers — a host
+        application that toggles verbosity at runtime must not see duplicate
+        log lines."""
+        dataxid.enable_logging("info")
+        dataxid.enable_logging("debug")
+        dataxid.enable_logging("warning")
+        assert len(_stream_handlers()) == 1
+        sensitive_filters = [
+            f for f in logger.filters if isinstance(f, SensitiveHeadersFilter)
+        ]
+        assert len(sensitive_filters) == 1
+        assert logger.level == logging.WARNING
+
+    def test_invalid_string_level_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Invalid log level"):
+            dataxid.enable_logging("invalid")
+
+    def test_int_level_raises_value_error(self) -> None:
+        """The public contract is string-only; passing ``logging.DEBUG`` (an
+        int) must raise ``ValueError`` rather than fail with an unrelated
+        ``AttributeError`` that callers would have to catch by accident."""
+        with pytest.raises(ValueError, match="Invalid log level"):
+            dataxid.enable_logging(logging.DEBUG)
+
+
+class TestDisableLogging:
+    """``disable_logging`` returns the logger to its silent default."""
+
+    def test_resets_level_to_notset(self) -> None:
+        dataxid.enable_logging("info")
+        dataxid.disable_logging()
+        assert logger.level == logging.NOTSET
+
+    def test_removes_stream_handlers(self) -> None:
+        dataxid.enable_logging("info")
+        dataxid.disable_logging()
+        assert _stream_handlers() == []
+
+    def test_keeps_null_handler_so_logger_stays_silent(self) -> None:
+        dataxid.enable_logging("info")
+        dataxid.disable_logging()
+        assert any(
+            isinstance(h, logging.NullHandler) for h in logger.handlers
+        )
+
+    def test_clears_sensitive_headers_filter(self) -> None:
+        dataxid.enable_logging("info")
+        dataxid.disable_logging()
+        assert logger.filters == []
+
+    def test_idempotent_when_logging_was_never_enabled(self) -> None:
+        """Tools that always call ``disable_logging`` on shutdown should not
+        crash if logging was never turned on in the first place."""
+        dataxid.disable_logging()
+        dataxid.disable_logging()
+        assert logger.level == logging.NOTSET
+
+
+class TestSensitiveHeadersFilter:
+    """``SensitiveHeadersFilter`` redacts API credentials in log records.
+
+    This filter is the only thing standing between an Authorization header
+    set by ``DataxidClient`` and a host application's log sink, so it must
+    handle every realistic shape of ``record.args`` without crashing.
+    """
+
+    @pytest.mark.parametrize(
+        "header_name",
+        [
+            "Authorization", "AUTHORIZATION", "authorization", "auThOrIzAtIon",
+            "X-Api-Key", "X-API-KEY", "x-api-key",
+        ],
+    )
+    def test_masks_credential_headers_case_insensitively(
+        self, header_name: str
+    ) -> None:
+        record = _make_record({"headers": {header_name: "secret_value"}})
+        SensitiveHeadersFilter().filter(record)
+        assert record.args["headers"][header_name] == "***"
+
+    def test_preserves_non_sensitive_headers(self) -> None:
+        record = _make_record(
+            {"headers": {"Content-Type": "application/json"}}
+        )
+        SensitiveHeadersFilter().filter(record)
+        assert record.args["headers"]["Content-Type"] == "application/json"
+
+    def test_redacts_sensitive_alongside_safe_headers(self) -> None:
+        record = _make_record({
+            "headers": {
+                "Authorization": "Bearer dx_123",
+                "Content-Type": "application/json",
+                "X-Api-Key": "dx_secret",
+            }
+        })
+        SensitiveHeadersFilter().filter(record)
+        masked = record.args["headers"]
+        assert masked["Authorization"] == "***"
+        assert masked["X-Api-Key"] == "***"
+        assert masked["Content-Type"] == "application/json"
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            None,
+            {"headers": None},
+            {"headers": "raw-string-not-a-dict"},
+            {"headers": 42},
+            {"unrelated": "value"},
+            (),
+        ],
+    )
+    def test_passes_through_unsupported_args_without_crashing(
+        self, args: Any
+    ) -> None:
+        """The filter must never break logging; unexpected ``args`` shapes
+        flow through untouched."""
+        record = _make_record(args)
+        assert SensitiveHeadersFilter().filter(record) is True
+
+
+class TestEnvVar:
+    """``DATAXID_LOG`` environment variable activates logging on demand."""
+
+    def test_activates_logging_at_requested_level(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DATAXID_LOG", "debug")
+        setup_logging()
+        assert logger.level == logging.DEBUG
+
+    def test_unset_env_leaves_logger_silent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DATAXID_LOG", raising=False)
+        setup_logging()
+        assert logger.level == logging.NOTSET
+        assert _stream_handlers() == []
+
+
+class TestTopLevelImport:
+    """``enable_logging`` / ``disable_logging`` are part of the public API."""
+
+    def test_reexported_at_package_root(self) -> None:
+        assert dataxid.enable_logging is dataxid._log.enable_logging
+        assert dataxid.disable_logging is dataxid._log.disable_logging
+
+    def test_listed_in_dunder_all(self) -> None:
+        assert "enable_logging" in dataxid.__all__
+        assert "disable_logging" in dataxid.__all__

--- a/tests/sdk/test_model.py
+++ b/tests/sdk/test_model.py
@@ -332,8 +332,9 @@ class TestGenerate:
              patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
             mock_req.side_effect = [_make_create_response()]
             model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
-            with pytest.raises(TypeError, match="Distribution instance"):
+            with pytest.raises(InvalidRequestError, match="Distribution instance") as exc_info:
                 model.generate(distribution={"column": "city", "probabilities": {"A": 1.0}})
+            assert exc_info.value.param == "distribution"
 
     def test_distribution_sets_fixed_probs_and_column_order(
         self, sample_df: pd.DataFrame, mock_train_frozen: None
@@ -1152,8 +1153,11 @@ class TestGenerateWithSynthetic:
     ) -> None:
         with patch.object(DataxidClient, "_request", return_value=_make_create_response()):
             model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
-        with pytest.raises(TypeError, match="synthetic must be a Synthetic instance"):
+        with pytest.raises(
+            InvalidRequestError, match="synthetic must be a Synthetic instance"
+        ) as exc_info:
             model.generate(synthetic={"diversity": 0.5})  # type: ignore[arg-type]
+        assert exc_info.value.param == "synthetic"
 
 
 class TestImpute:

--- a/tests/sdk/test_model.py
+++ b/tests/sdk/test_model.py
@@ -1,0 +1,1367 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+End-to-end integration tests for the :class:`dataxid.Model` orchestration layer.
+
+These tests stub out the HTTP transport (``DataxidClient._request``) and the
+local frozen-training loop, then exercise the public model lifecycle:
+
+* :meth:`Model.create` — analyze + ``POST /v1/models`` + frozen training
+* :meth:`Model.generate` — local encode + ``POST /v1/models/{id}/generate``
+* :meth:`Model.delete` — ``DELETE /v1/models/{id}``
+* :meth:`Model.refresh` — ``GET /v1/models/{id}``
+* :meth:`Model.impute` — generate-driven imputation
+* :func:`dataxid.synthesize` — one-shot create+generate+delete convenience
+
+The goal is to pin the *contract* between the SDK orchestration layer and the
+HTTP client (request shape, sequencing, error propagation) without exercising
+real network I/O.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+import dataxid
+from dataxid.client._http import DataxidClient
+from dataxid.client._serialization import deserialize_embedding
+from dataxid.encoder._wrapper import Encoder
+from dataxid.exceptions import (
+    AuthenticationError,
+    InvalidRequestError,
+    NotFoundError,
+)
+from dataxid.training._config import Distribution, ModelConfig, Synthetic
+from dataxid.training._model import Model
+
+MODEL_ID = "mdl_test_abc123"
+EMBEDDING_DIM = 16
+N_ROWS = 8
+
+SEQ_N_ENTITIES = 3
+SEQ_LEN_MAX = 3
+
+_DEFAULT_CONFIG: dict[str, Any] = {
+    "embedding_dim": EMBEDDING_DIM,
+    "model_size": "small",
+    "max_epochs": 1,
+}
+
+
+@pytest.fixture
+def sample_df() -> pd.DataFrame:
+    return pd.DataFrame({
+        "age": [25, 30, 35, 40, 45, 50, 55, 60],
+        "city": ["A", "B", "A", "C", "B", "A", "C", "B"],
+    })
+
+
+@pytest.fixture
+def ctx_df() -> pd.DataFrame:
+    return pd.DataFrame({
+        "region": ["North", "South", "North", "East", "South", "North", "East", "South"],
+        "population": [100, 200, 100, 300, 200, 100, 300, 200],
+    })
+
+
+@pytest.fixture
+def seq_df() -> pd.DataFrame:
+    return pd.DataFrame({
+        "account_id": [1, 1, 1, 2, 2, 3, 3, 3],
+        "amount": [100.0, 200.0, 150.0, 300.0, 250.0, 50.0, 75.0, 60.0],
+        "type": ["credit", "debit", "credit", "debit", "credit", "credit", "debit", "credit"],
+    })
+
+
+@pytest.fixture
+def seq_ctx_df() -> pd.DataFrame:
+    return pd.DataFrame({
+        "id": [1, 2, 3],
+        "region": ["North", "South", "East"],
+    })
+
+
+@pytest.fixture(autouse=True)
+def _set_api_key() -> Iterator[None]:
+    """Ensure every test runs with a deterministic API key, restored after."""
+    original = dataxid.api_key
+    dataxid.api_key = "dx_test_integration"
+    yield
+    dataxid.api_key = original
+
+
+@pytest.fixture
+def mock_train_frozen() -> Iterator[None]:
+    """Replace the local training loop with a deterministic 'ready' stub."""
+    def _fake_train(model: Model, **_kwargs: Any) -> None:
+        model.train_losses = [0.5]
+        model.val_losses = [0.4]
+        model.stopped_early = False
+        model.status = "ready"
+
+    with patch("dataxid.training._model.train_frozen", _fake_train):
+        yield
+
+
+def _make_create_response() -> dict[str, Any]:
+    return {
+        "data": {
+            "id": MODEL_ID,
+            "status": "training",
+            "config": {"embedding_dim": EMBEDDING_DIM, "model_size": "small"},
+        }
+    }
+
+
+def _make_generate_response(n_samples: int = N_ROWS) -> dict[str, Any]:
+    return {
+        "data": {
+            "n_rows": n_samples,
+            "n_cols": 2,
+            "columns": ["feat:/age__cat", "feat:/city__cat"],
+            "codes": {
+                "feat:/age__cat": list(range(n_samples)),
+                "feat:/city__cat": [0] * n_samples,
+            },
+        }
+    }
+
+
+def _make_sequential_generate_response() -> dict[str, Any]:
+    """Mock sequential codes: ``{sub_col: [[entity0_vals], [entity1_vals], ...]}``."""
+    from dataxid.encoder._nn import RIDX_PREFIX, SIDX_PREFIX, SLEN_PREFIX
+    return {
+        "data": {
+            "n_rows": SEQ_N_ENTITIES,
+            "n_cols": 4,
+            "columns": [
+                f"{SIDX_PREFIX}cat", f"{SLEN_PREFIX}cat", f"{RIDX_PREFIX}cat",
+                "feat:/amount__cat", "feat:/type__cat",
+            ],
+            "codes": {
+                f"{SIDX_PREFIX}cat": [[0, 1, 2], [0, 1, 0], [0, 1, 2]],
+                f"{SLEN_PREFIX}cat": [[3, 3, 3], [2, 2, 0], [3, 3, 3]],
+                f"{RIDX_PREFIX}cat": [[3, 2, 1], [2, 1, 0], [3, 2, 1]],
+                "feat:/amount__cat": [[1, 2, 1], [3, 2, 0], [0, 1, 0]],
+                "feat:/type__cat": [[0, 1, 0], [1, 0, 0], [0, 1, 0]],
+            },
+        }
+    }
+
+
+def _flat_decode(
+    raw_codes: dict[str, Any],
+    features: Any,
+    column_stats: Any,
+    **_kwargs: Any,
+) -> pd.DataFrame:
+    """Decode stub for flat (non-sequential) generate responses."""
+    n = len(next(iter(raw_codes.values())))
+    return pd.DataFrame({"age": list(range(n)), "city": ["A"] * n})
+
+
+def _seq_decode(
+    raw_codes: dict[str, Any],
+    features: Any,
+    column_stats: Any,
+    **_kwargs: Any,
+) -> pd.DataFrame:
+    """Decode stub for sequential generate responses."""
+    n = len(next(iter(raw_codes.values())))
+    return pd.DataFrame({"amount": list(range(n)), "type": ["credit"] * n})
+
+
+class _Driver:
+    """Single source of truth for the create-then-do-something setup pattern.
+
+    Centralises the boilerplate of patching ``DataxidClient._request`` and
+    ``decode_columns`` for a sequence of HTTP responses, so individual tests
+    only express the *intent* (which generate / delete / impute payloads they
+    expect) and the assertions.
+    """
+
+    def __init__(self, mock_req: Any, decode_stub: Any = _flat_decode) -> None:
+        self.mock_req = mock_req
+        self.decode_stub = decode_stub
+
+    def queue(self, *responses: Any) -> None:
+        """Set the side-effect queue for ``DataxidClient._request``."""
+        self.mock_req.side_effect = list(responses)
+
+    def call_args(self, index: int) -> Any:
+        return self.mock_req.call_args_list[index]
+
+    def json_at(self, index: int) -> dict[str, Any]:
+        return self.mock_req.call_args_list[index][1]["json"]
+
+    def last_json(self) -> dict[str, Any]:
+        return self.mock_req.call_args_list[-1][1]["json"]
+
+
+class TestModelCreate:
+    """Model.create() returns a ready model and POSTs the expected payload."""
+
+    def test_returns_ready_model_with_id(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()):
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+        assert model.id == MODEL_ID
+        assert model.status == "ready"
+
+    def test_first_call_posts_to_models_endpoint(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()) as mock_req:
+            Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+        first_call = mock_req.call_args_list[0]
+        assert first_call[0][0] == "POST"
+        assert first_call[0][1] == "/v1/models"
+
+    def test_metadata_payload_contains_features(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()) as mock_req:
+            Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+        body = mock_req.call_args_list[0][1]["json"]
+        assert "metadata" in body
+        assert body["metadata"]["features"] == ["age", "city"]
+
+    def test_accepts_modelconfig_instance(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        cfg = ModelConfig(embedding_dim=EMBEDDING_DIM, model_size="small", max_epochs=1)
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()):
+            model = Model.create(data=sample_df, config=cfg)
+        assert model.id == MODEL_ID
+
+    def test_modelconfig_and_dict_produce_identical_payload(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        """Dict and ModelConfig inputs must serialize to the same wire format."""
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()) as mock_dict:
+            Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+        dict_body = mock_dict.call_args_list[0][1]["json"]
+
+        cfg = ModelConfig(embedding_dim=EMBEDDING_DIM, model_size="small", max_epochs=1)
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()) as mock_cfg:
+            Model.create(data=sample_df, config=cfg)
+        cfg_body = mock_cfg.call_args_list[0][1]["json"]
+
+        assert dict_body["config"] == cfg_body["config"]
+
+
+class TestGenerate:
+    """Model.generate() returns decoded rows and forwards the right payload."""
+
+    def test_returns_dataframe_of_expected_shape(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(N_ROWS))
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            result = model.generate()
+        assert len(result) == N_ROWS
+        assert list(result.columns) == ["age", "city"]
+        assert model.status == "ready"
+
+    def test_default_generation_sends_zero_embedding(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(N_ROWS))
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate()
+        body = d.json_at(1)
+        assert isinstance(body["embedding"], dict)
+        assert body["embedding"]["shape"] == [N_ROWS, EMBEDDING_DIM]
+        emb = deserialize_embedding(body["embedding"])
+        assert torch.all(emb == 0), "Default generation must use zero embedding"
+
+    def test_conditional_generation_keeps_zero_embedding(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        """Conditioning is via fixed_values, not the embedding tensor."""
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(N_ROWS))
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate(conditions=sample_df)
+        body = d.json_at(1)
+        assert body["embedding"]["shape"] == [N_ROWS, EMBEDDING_DIM]
+        emb = deserialize_embedding(body["embedding"])
+        assert torch.all(emb == 0)
+
+    def test_seed_forwarded_when_set(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(N_ROWS))
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate(seed=42)
+        assert d.json_at(1)["seed"] == 42
+
+    def test_seed_omitted_when_none(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(N_ROWS))
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate()
+        assert "seed" not in d.json_at(1)
+
+    def test_distribution_dict_rejected(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        """Plain dict for ``distribution=`` is a typed-API mistake; raise early."""
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            mock_req.side_effect = [_make_create_response()]
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            with pytest.raises(TypeError, match="Distribution instance"):
+                model.generate(distribution={"column": "city", "probabilities": {"A": 1.0}})
+
+    def test_distribution_sets_fixed_probs_and_column_order(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        dist = Distribution(column="city", probabilities={"A": 0.8, "B": 0.2})
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(N_ROWS))
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate(distribution=dist)
+        body = d.json_at(1)
+        assert "fixed_probs" in body
+        assert body["column_order"][0] == "feat:/city"
+
+    def test_no_distribution_omits_column_order(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(N_ROWS))
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate()
+        assert "column_order" not in d.json_at(1)
+
+    def test_conditions_send_fixed_values_and_column_order(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        conds = pd.DataFrame({"city": ["A", "B"]})
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode), \
+             patch.object(Encoder, "_generation_embedding",
+                          return_value=torch.zeros(2, EMBEDDING_DIM)):
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(2))
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate(conditions=conds)
+        body = d.json_at(1)
+        assert isinstance(body["fixed_values"], dict)
+        assert body["column_order"][0] == "feat:/city"
+
+    def test_conditions_drive_n_samples(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        conds = pd.DataFrame({"city": ["A", "B", "C"]})
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode), \
+             patch.object(Encoder, "_generation_embedding",
+                          return_value=torch.zeros(3, EMBEDDING_DIM)) as mock_emb:
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(3))
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate(conditions=conds)
+        mock_emb.assert_called_once()
+        assert mock_emb.call_args[1]["n_samples"] == 3
+
+    def test_conditions_conflicting_n_samples_raises(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        conds = pd.DataFrame({"city": ["A", "B"]})
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            mock_req.side_effect = [_make_create_response(), _make_generate_response(2)]
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            with pytest.raises(ValueError, match="conflicts with conditions length"):
+                model.generate(conditions=conds, n_samples=99)
+
+    def test_conditions_with_matching_n_samples(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        conds = pd.DataFrame({"city": ["A", "B"]})
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode), \
+             patch.object(Encoder, "_generation_embedding",
+                          return_value=torch.zeros(2, EMBEDDING_DIM)):
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(2))
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            result = model.generate(conditions=conds, n_samples=2)
+        assert len(result) == 2
+
+    def test_conditions_combined_with_distribution(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        conds = pd.DataFrame({"city": ["A", "B"]})
+        dist = Distribution(column="city", probabilities={"A": 0.5, "B": 0.5})
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode), \
+             patch.object(Encoder, "_generation_embedding",
+                          return_value=torch.zeros(2, EMBEDDING_DIM)):
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(2))
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate(conditions=conds, distribution=dist)
+        body = d.json_at(1)
+        assert "fixed_values" in body
+        assert body["column_order"][0] == "feat:/city"
+
+    def test_no_conditions_omits_fixed_values(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(N_ROWS))
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate()
+        assert "fixed_values" not in d.json_at(1)
+
+
+class TestDelete:
+    """Model.delete() issues DELETE and updates local status."""
+
+    def test_calls_delete_with_model_id(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req:
+            mock_req.side_effect = [_make_create_response(), None]
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.delete()
+        delete_call = mock_req.call_args_list[1]
+        assert delete_call[0][0] == "DELETE"
+        assert MODEL_ID in delete_call[0][1]
+        assert model.status == "deleted"
+
+
+class TestRefresh:
+    """Model.refresh() issues GET and updates local status from API."""
+
+    def test_get_request_updates_status(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req:
+            mock_req.side_effect = [
+                _make_create_response(),
+                {"data": {"id": MODEL_ID, "status": "ready", "epoch": 1}},
+            ]
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            data = model.refresh()
+        refresh_call = mock_req.call_args_list[1]
+        assert refresh_call[0][0] == "GET"
+        assert model.status == "ready"
+        assert data["id"] == MODEL_ID
+
+
+class TestSynthesize:
+    """``dataxid.synthesize()`` chains create → generate → delete."""
+
+    def test_returns_dataframe_of_requested_size(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            mock_req.side_effect = [
+                _make_create_response(),
+                _make_generate_response(N_ROWS),
+                None,  # delete
+            ]
+            result = dataxid.synthesize(
+                data=sample_df, n_samples=N_ROWS, config=_DEFAULT_CONFIG,
+            )
+        assert len(result) == N_ROWS
+
+    def test_delete_called_after_generate(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            mock_req.side_effect = [
+                _make_create_response(),
+                _make_generate_response(N_ROWS),
+                None,
+            ]
+            dataxid.synthesize(
+                data=sample_df, n_samples=N_ROWS, config=_DEFAULT_CONFIG,
+            )
+        assert mock_req.call_args_list[-1][0][0] == "DELETE"
+
+    def test_synthesize_with_parent(
+        self,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        """Parent table is forwarded through the convenience wrapper."""
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            mock_req.side_effect = [
+                _make_create_response(),
+                _make_generate_response(N_ROWS),
+                None,
+            ]
+            result = dataxid.synthesize(
+                data=sample_df, n_samples=N_ROWS, parent=ctx_df, config=_DEFAULT_CONFIG,
+            )
+        assert len(result) == N_ROWS
+
+    def test_delete_called_when_generate_fails(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        """Synthesize must clean up the temporary model even on failure."""
+        with patch.object(DataxidClient, "_request") as mock_req:
+            mock_req.side_effect = [
+                _make_create_response(),
+                Exception("generate failed"),
+                None,
+            ]
+            with pytest.raises(Exception, match="generate failed"):
+                dataxid.synthesize(
+                    data=sample_df, n_samples=N_ROWS, config=_DEFAULT_CONFIG,
+                )
+        delete_calls = [c for c in mock_req.call_args_list if c[0][0] == "DELETE"]
+        assert len(delete_calls) == 1
+
+
+class TestStatusTransitions:
+    """The full create → generate → delete lifecycle keeps status coherent."""
+
+    def test_full_lifecycle(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            mock_req.side_effect = [
+                _make_create_response(),
+                _make_generate_response(N_ROWS),
+                None,  # delete
+            ]
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            assert model.status == "ready"
+            model.generate()
+            assert model.status == "ready"
+            model.delete()
+            assert model.status == "deleted"
+
+
+class TestModelCreateWithContext:
+    """Flat multitable: ``parent=`` carries context but does not enable sequential mode."""
+
+    def test_returns_model_with_parent(
+        self,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()):
+            model = Model.create(data=sample_df, parent=ctx_df, config=_DEFAULT_CONFIG)
+        assert model._parent is not None
+
+    def test_metadata_marks_has_context(
+        self,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()) as mock_req:
+            Model.create(data=sample_df, parent=ctx_df, config=_DEFAULT_CONFIG)
+        assert mock_req.call_args_list[0][1]["json"]["metadata"]["has_context"] is True
+
+    def test_metadata_cardinality_count_unchanged_by_context(
+        self,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        """Adding context must not leak the parent's cardinalities into the body."""
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()) as mock_req:
+            Model.create(data=sample_df, parent=ctx_df, config=_DEFAULT_CONFIG)
+        body = mock_req.call_args_list[0][1]["json"]
+        no_ctx = Encoder(embedding_dim=EMBEDDING_DIM, model_size="small")
+        meta_flat = no_ctx.analyze(sample_df)
+        assert len(body["metadata"]["cardinalities"]) == len(meta_flat["cardinalities"])
+
+
+class TestGenerateWithContext:
+    """Generate honours both the training-time and call-time context tables."""
+
+    def test_generate_uses_training_context(
+        self,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(N_ROWS))
+            model = Model.create(data=sample_df, parent=ctx_df, config=_DEFAULT_CONFIG)
+            result = model.generate()
+        assert len(result) == N_ROWS
+
+    def test_generate_with_explicit_context(
+        self,
+        sample_df: pd.DataFrame,
+        ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(N_ROWS))
+            model = Model.create(data=sample_df, parent=ctx_df, config=_DEFAULT_CONFIG)
+            result = model.generate(parent=ctx_df)
+        assert len(result) == N_ROWS
+
+
+class TestSequentialModelCreate:
+    """Sequential (time series) mode adds entity / sequence-length metadata."""
+
+    def test_returns_sequential_model(
+        self,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()):
+            model = Model.create(
+                data=seq_df, parent=seq_ctx_df,
+                foreign_key="account_id", parent_key="id",
+                config=_DEFAULT_CONFIG,
+            )
+        assert model.is_sequential is True
+
+    def test_metadata_carries_sequence_lengths(
+        self,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()) as mock_req:
+            Model.create(
+                data=seq_df, parent=seq_ctx_df,
+                foreign_key="account_id", parent_key="id",
+                config=_DEFAULT_CONFIG,
+            )
+        meta = mock_req.call_args_list[0][1]["json"]["metadata"]
+        assert meta["is_sequential"] is True
+        assert meta["seq_len_max"] == 3
+        assert meta["seq_len_median"] >= 2
+
+    def test_positional_cardinalities_in_metadata(
+        self,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        from dataxid.encoder._nn import SIDX_PREFIX
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()) as mock_req:
+            Model.create(
+                data=seq_df, parent=seq_ctx_df,
+                foreign_key="account_id", parent_key="id",
+                config=_DEFAULT_CONFIG,
+            )
+        cards = mock_req.call_args_list[0][1]["json"]["metadata"]["cardinalities"]
+        assert any(k.startswith(SIDX_PREFIX) for k in cards)
+
+
+class TestSequentialGenerate:
+    def test_payload_carries_sequential_flag(
+        self,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_seq_decode):
+            d = _Driver(mock_req, decode_stub=_seq_decode)
+            d.queue(_make_create_response(), _make_sequential_generate_response())
+            model = Model.create(
+                data=seq_df, parent=seq_ctx_df,
+                foreign_key="account_id", parent_key="id",
+                config=_DEFAULT_CONFIG,
+            )
+            model.generate()
+        body = d.json_at(1)
+        assert body["is_sequential"] is True
+        assert body["seq_len_max"] == SEQ_LEN_MAX
+
+    def test_returns_flattened_dataframe(
+        self,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_seq_decode):
+            d = _Driver(mock_req, decode_stub=_seq_decode)
+            d.queue(_make_create_response(), _make_sequential_generate_response())
+            model = Model.create(
+                data=seq_df, parent=seq_ctx_df,
+                foreign_key="account_id", parent_key="id",
+                config=_DEFAULT_CONFIG,
+            )
+            result = model.generate()
+        assert "account_id" in result.columns
+        assert len(result) == 8
+
+    def test_conditions_send_2d_fixed_values(
+        self,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        """Sequential conditions (long-format) → 2D fixed_values in the payload."""
+        conds = pd.DataFrame({
+            "account_id": [1, 1, 2, 3],
+            "type": ["debit", "credit", "debit", "credit"],
+        })
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_seq_decode):
+            d = _Driver(mock_req, decode_stub=_seq_decode)
+            d.queue(_make_create_response(), _make_sequential_generate_response())
+            model = Model.create(
+                data=seq_df, parent=seq_ctx_df,
+                foreign_key="account_id", parent_key="id",
+                config=_DEFAULT_CONFIG,
+            )
+            model.generate(conditions=conds)
+        fv = d.json_at(1)["fixed_values"]
+        assert isinstance(fv, dict)
+        for vals in fv.values():
+            assert all(isinstance(row, list) for row in vals), \
+                "Sequential fixed_values must be 2D (list of lists)"
+            assert len(vals) == SEQ_N_ENTITIES
+
+    def test_conditions_send_column_order(
+        self,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        conds = pd.DataFrame({
+            "account_id": [1, 2, 3],
+            "type": ["debit", "debit", "debit"],
+        })
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_seq_decode):
+            d = _Driver(mock_req, decode_stub=_seq_decode)
+            d.queue(_make_create_response(), _make_sequential_generate_response())
+            model = Model.create(
+                data=seq_df, parent=seq_ctx_df,
+                foreign_key="account_id", parent_key="id",
+                config=_DEFAULT_CONFIG,
+            )
+            model.generate(conditions=conds)
+        assert d.json_at(1)["column_order"][0] == "feat:/type"
+
+    def test_conditions_missing_foreign_key_raises(
+        self,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        conds = pd.DataFrame({"type": ["debit", "credit"]})
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_seq_decode):
+            mock_req.side_effect = [
+                _make_create_response(),
+                _make_sequential_generate_response(),
+            ]
+            model = Model.create(
+                data=seq_df, parent=seq_ctx_df,
+                foreign_key="account_id", parent_key="id",
+                config=_DEFAULT_CONFIG,
+            )
+            with pytest.raises(ValueError, match="foreign key column"):
+                model.generate(conditions=conds)
+
+    def test_no_conditions_omits_fixed_values(
+        self,
+        seq_df: pd.DataFrame,
+        seq_ctx_df: pd.DataFrame,
+        mock_train_frozen: None,
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_seq_decode):
+            d = _Driver(mock_req, decode_stub=_seq_decode)
+            d.queue(_make_create_response(), _make_sequential_generate_response())
+            model = Model.create(
+                data=seq_df, parent=seq_ctx_df,
+                foreign_key="account_id", parent_key="id",
+                config=_DEFAULT_CONFIG,
+            )
+            model.generate()
+        assert "fixed_values" not in d.json_at(1)
+
+
+class TestBackwardCompatModel:
+    """Flat mode is unaffected by sequential additions."""
+
+    def test_flat_create_metadata_not_sequential(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()) as mock_req:
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+        body = mock_req.call_args_list[0][1]["json"]
+        assert body["metadata"]["is_sequential"] is False
+        assert model.is_sequential is False
+
+    def test_flat_generate_omits_sequential_flag(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode):
+            d = _Driver(mock_req)
+            d.queue(_make_create_response(), _make_generate_response(N_ROWS))
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate()
+        assert "is_sequential" not in d.json_at(1)
+
+
+class TestInputValidation:
+    """Invalid context/sequential parameter combinations raise InvalidRequestError early."""
+
+    def test_parent_encoding_types_without_parent(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        with pytest.raises(InvalidRequestError, match="without parent"):
+            Model.create(
+                data=sample_df,
+                parent_encoding_types={"col": "categorical"},
+                config={"embedding_dim": EMBEDDING_DIM, "model_size": "small"},
+            )
+
+    def test_parent_key_without_parent(self, sample_df: pd.DataFrame) -> None:
+        with pytest.raises(InvalidRequestError, match="without parent"):
+            Model.create(
+                data=sample_df,
+                parent_key="id",
+                config={"embedding_dim": EMBEDDING_DIM, "model_size": "small"},
+            )
+
+    def test_foreign_key_not_in_data(self, sample_df: pd.DataFrame) -> None:
+        with pytest.raises(InvalidRequestError, match="not found in data"):
+            Model.create(
+                data=sample_df,
+                foreign_key="nonexistent_col",
+                config={"embedding_dim": EMBEDDING_DIM, "model_size": "small"},
+            )
+
+    def test_parent_key_not_in_parent(self, sample_df: pd.DataFrame) -> None:
+        ctx = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6, 7, 8]})
+        with pytest.raises(InvalidRequestError, match="not found in parent"):
+            Model.create(
+                data=sample_df,
+                parent=ctx,
+                parent_key="missing_pk",
+                config={"embedding_dim": EMBEDDING_DIM, "model_size": "small"},
+            )
+
+    def test_parent_row_count_mismatch_flat(self, sample_df: pd.DataFrame) -> None:
+        ctx = pd.DataFrame({"x": [1, 2, 3]})
+        with pytest.raises(InvalidRequestError, match="Row count mismatch"):
+            Model.create(
+                data=sample_df,
+                parent=ctx,
+                config={"embedding_dim": EMBEDDING_DIM, "model_size": "small"},
+            )
+
+    def test_sequential_without_parent(self) -> None:
+        df = pd.DataFrame({
+            "entity_id": [1, 1, 2, 2, 3, 3],
+            "value": [10, 20, 30, 40, 50, 60],
+        })
+        with pytest.raises(InvalidRequestError, match="Sequential mode requires parent"):
+            Model.create(
+                data=df,
+                foreign_key="entity_id",
+                config={"embedding_dim": EMBEDDING_DIM, "model_size": "small"},
+            )
+
+    def test_invalid_request_error_carries_param_attr(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        with pytest.raises(InvalidRequestError) as exc_info:
+            Model.create(
+                data=sample_df,
+                parent_encoding_types={"col": "categorical"},
+                config={"embedding_dim": EMBEDDING_DIM, "model_size": "small"},
+            )
+        assert exc_info.value.param == "parent_encoding_types"
+
+    def test_valid_flat_context_passes(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        ctx = pd.DataFrame({"pop": [100] * 8})
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()):
+            model = Model.create(data=sample_df, parent=ctx, config=_DEFAULT_CONFIG)
+        assert model.has_context is True
+
+
+class TestGenerationSamplingParams:
+    """Generation knobs (diversity / rare_cutoff / rare_strategy) — validation + payload forwarding."""
+
+    def _train_and_generate(
+        self, sample_df: pd.DataFrame, **generate_kwargs: Any
+    ) -> dict[str, Any]:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode), \
+             patch("dataxid.training._model.train_frozen",
+                   lambda model, **_: setattr(model, "status", "ready")):
+            mock_req.side_effect = [_make_create_response(), _make_generate_response(N_ROWS)]
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate(**generate_kwargs)
+        return mock_req.call_args_list[1][1]["json"]
+
+    @pytest.mark.parametrize("value", [0, -0.1, -1.0])
+    def test_diversity_non_positive_rejected(
+        self, sample_df: pd.DataFrame, value: float, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()):
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+        with pytest.raises(ValueError, match="diversity"):
+            model.generate(diversity=value)
+
+    @pytest.mark.parametrize("value", [0, -0.1, 1.01, 2.0])
+    def test_rare_cutoff_out_of_range_rejected(
+        self, sample_df: pd.DataFrame, value: float, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()):
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+        with pytest.raises(ValueError, match="rare_cutoff"):
+            model.generate(rare_cutoff=value)
+
+    def test_invalid_rare_strategy_rejected(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()):
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+        with pytest.raises(ValueError, match="rare_strategy"):
+            model.generate(rare_strategy="invalid")  # type: ignore[arg-type]
+
+    def test_defaults_omit_diversity_and_rare_cutoff(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        body = self._train_and_generate(sample_df)
+        assert "diversity" not in body
+        assert "rare_cutoff" not in body
+
+    def test_non_default_diversity_sent(self, sample_df: pd.DataFrame) -> None:
+        body = self._train_and_generate(sample_df, diversity=0.5)
+        assert body["diversity"] == 0.5
+
+    def test_non_default_rare_cutoff_sent(self, sample_df: pd.DataFrame) -> None:
+        body = self._train_and_generate(sample_df, rare_cutoff=0.9)
+        assert body["rare_cutoff"] == 0.9
+
+    def test_both_non_default_sent(self, sample_df: pd.DataFrame) -> None:
+        body = self._train_and_generate(sample_df, diversity=0.7, rare_cutoff=0.8)
+        assert body["diversity"] == 0.7
+        assert body["rare_cutoff"] == 0.8
+
+    @pytest.mark.parametrize("strategy", ["mask", "sample"])
+    def test_rare_strategy_forwarded_to_decode(
+        self, sample_df: pd.DataFrame, strategy: str
+    ) -> None:
+        """Regression guard: client and server must agree on whether
+        ``<protected>`` is visible in the output."""
+        seen: dict[str, Any] = {}
+
+        def _spy_decode(raw_codes: Any, features: Any, column_stats: Any, **kwargs: Any) -> pd.DataFrame:
+            seen.update(kwargs)
+            return _flat_decode(raw_codes, features, column_stats)
+
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_spy_decode), \
+             patch("dataxid.training._model.train_frozen",
+                   lambda model, **_: setattr(model, "status", "ready")):
+            mock_req.side_effect = [_make_create_response(), _make_generate_response(N_ROWS)]
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate(rare_strategy=strategy)
+
+        assert seen.get("rare_strategy") == strategy
+
+    def test_rare_strategy_default_inherits_from_privacy(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        """Omitted ``rare_strategy=`` falls through to ``ModelConfig.privacy.rare_strategy``."""
+        seen: dict[str, Any] = {}
+
+        def _spy_decode(raw_codes: Any, features: Any, column_stats: Any, **kwargs: Any) -> pd.DataFrame:
+            seen.update(kwargs)
+            return _flat_decode(raw_codes, features, column_stats)
+
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_spy_decode), \
+             patch("dataxid.training._model.train_frozen",
+                   lambda model, **_: setattr(model, "status", "ready")):
+            mock_req.side_effect = [_make_create_response(), _make_generate_response(N_ROWS)]
+            model = Model.create(
+                data=sample_df,
+                config={**_DEFAULT_CONFIG, "privacy": {"rare_strategy": "sample"}},
+            )
+            model.generate()
+
+        assert seen.get("rare_strategy") == "sample"
+
+    def test_rare_strategy_explicit_overrides_privacy(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        """Explicit ``rare_strategy=`` on ``generate()`` wins over Privacy's setting."""
+        seen: dict[str, Any] = {}
+
+        def _spy_decode(raw_codes: Any, features: Any, column_stats: Any, **kwargs: Any) -> pd.DataFrame:
+            seen.update(kwargs)
+            return _flat_decode(raw_codes, features, column_stats)
+
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_spy_decode), \
+             patch("dataxid.training._model.train_frozen",
+                   lambda model, **_: setattr(model, "status", "ready")):
+            mock_req.side_effect = [_make_create_response(), _make_generate_response(N_ROWS)]
+            model = Model.create(
+                data=sample_df,
+                config={**_DEFAULT_CONFIG, "privacy": {"rare_strategy": "sample"}},
+            )
+            model.generate(rare_strategy="mask")
+
+        assert seen.get("rare_strategy") == "mask"
+
+
+class TestGenerateWithSynthetic:
+    """``Synthetic`` preset override semantics.
+
+    Rule: explicit keyword > ``synthetic.<field>`` > ``generate()`` default. A
+    preset is never silently overridden by a default — only by an explicit
+    keyword argument.
+    """
+
+    def _train_and_generate(
+        self, sample_df: pd.DataFrame, **generate_kwargs: Any
+    ) -> dict[str, Any]:
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_flat_decode), \
+             patch("dataxid.training._model.train_frozen",
+                   lambda model, **_: setattr(model, "status", "ready")):
+            mock_req.side_effect = [_make_create_response(), _make_generate_response(N_ROWS)]
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate(**generate_kwargs)
+        return mock_req.call_args_list[1][1]["json"]
+
+    def _train_and_generate_with_decode_spy(
+        self, sample_df: pd.DataFrame, **generate_kwargs: Any
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        seen: dict[str, Any] = {}
+
+        def _spy_decode(raw_codes: Any, features: Any, column_stats: Any, **kwargs: Any) -> pd.DataFrame:
+            seen.update(kwargs)
+            return _flat_decode(raw_codes, features, column_stats)
+
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_spy_decode), \
+             patch("dataxid.training._model.train_frozen",
+                   lambda model, **_: setattr(model, "status", "ready")):
+            mock_req.side_effect = [_make_create_response(), _make_generate_response(N_ROWS)]
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            model.generate(**generate_kwargs)
+        return mock_req.call_args_list[1][1]["json"], seen
+
+    def test_preset_scalar_fields_forwarded(self, sample_df: pd.DataFrame) -> None:
+        body = self._train_and_generate(
+            sample_df, synthetic=Synthetic(diversity=0.7, rare_cutoff=0.9),
+        )
+        assert body["diversity"] == 0.7
+        assert body["rare_cutoff"] == 0.9
+
+    def test_preset_seed_forwarded_to_payload(self, sample_df: pd.DataFrame) -> None:
+        body = self._train_and_generate(sample_df, synthetic=Synthetic(seed=123))
+        assert body.get("seed") == 123
+
+    def test_preset_rare_strategy_reaches_decode(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        _, decode_kwargs = self._train_and_generate_with_decode_spy(
+            sample_df, synthetic=Synthetic(rare_strategy="mask"),
+        )
+        assert decode_kwargs.get("rare_strategy") == "mask"
+
+    def test_kwarg_overrides_preset(self, sample_df: pd.DataFrame) -> None:
+        body = self._train_and_generate(
+            sample_df, synthetic=Synthetic(diversity=0.5), diversity=0.9,
+        )
+        assert body["diversity"] == 0.9
+
+    def test_preset_alone_leaves_unset_kwargs_at_defaults(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        """Fields missing from the preset must not appear in the payload."""
+        body = self._train_and_generate(sample_df, synthetic=Synthetic(diversity=0.5))
+        assert body["diversity"] == 0.5
+        assert "rare_cutoff" not in body
+
+    def test_preset_n_sets_n_samples(self, sample_df: pd.DataFrame) -> None:
+        body = self._train_and_generate(sample_df, synthetic=Synthetic(n=5))
+        assert body["embedding"]["shape"][0] == 5
+
+    def test_explicit_n_samples_matching_preset_is_ok(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        body = self._train_and_generate(
+            sample_df, n_samples=5, synthetic=Synthetic(n=5),
+        )
+        assert body["embedding"]["shape"][0] == 5
+
+    def test_explicit_n_samples_conflicting_preset_raises(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()):
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+        with pytest.raises(ValueError, match="conflicts with synthetic.n"):
+            model.generate(n_samples=5, synthetic=Synthetic(n=10))
+
+    def test_non_synthetic_preset_rejected(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request", return_value=_make_create_response()):
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+        with pytest.raises(TypeError, match="synthetic must be a Synthetic instance"):
+            model.generate(synthetic={"diversity": 0.5})  # type: ignore[arg-type]
+
+
+class TestImpute:
+    """Model.impute() drives generate-based imputation, then merges with the input."""
+
+    @staticmethod
+    def _impute_decode(
+        raw_codes: dict[str, Any],
+        features: Any,
+        column_stats: Any,
+        **_kwargs: Any,
+    ) -> pd.DataFrame:
+        n = len(next(iter(raw_codes.values())))
+        return pd.DataFrame({"age": [99] * n, "city": ["Z"] * n})
+
+    def _create_model(self, sample_df: pd.DataFrame, mock_req: Any) -> Model:
+        mock_req.side_effect = [_make_create_response(), _make_generate_response(N_ROWS)]
+        return Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+
+    def test_returns_dataframe(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        dirty = sample_df.copy()
+        dirty.loc[0, "age"] = None
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=self._impute_decode):
+            mock_req.side_effect = [_make_create_response(), _make_generate_response(N_ROWS)]
+            model = self._create_model(sample_df, mock_req)
+            mock_req.side_effect = [_make_generate_response(N_ROWS)]
+            result = model.impute(dirty)
+        assert len(result) == N_ROWS
+
+    def test_imputation_columns_sent_in_payload(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        dirty = sample_df.copy()
+        dirty.loc[0, "age"] = None
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=self._impute_decode):
+            model = self._create_model(sample_df, mock_req)
+            mock_req.side_effect = [_make_generate_response(N_ROWS)]
+            model.impute(dirty)
+        body = mock_req.call_args_list[-1][1]["json"]
+        assert set(body["imputation_columns"]) == {"age"}
+
+    def test_fixed_probs_include_imputation_suppression(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        dirty = sample_df.copy()
+        dirty.loc[0, "city"] = None
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=self._impute_decode):
+            model = self._create_model(sample_df, mock_req)
+            mock_req.side_effect = [_make_generate_response(N_ROWS)]
+            model.impute(dirty)
+        assert "fixed_probs" in mock_req.call_args_list[-1][1]["json"]
+
+    def test_payload_includes_column_order(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        dirty = sample_df.copy()
+        dirty.loc[0, "age"] = None
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=self._impute_decode):
+            model = self._create_model(sample_df, mock_req)
+            mock_req.side_effect = [_make_generate_response(N_ROWS)]
+            model.impute(dirty)
+        assert "column_order" in mock_req.call_args_list[-1][1]["json"]
+
+    def test_seed_merge_preserves_non_null_values(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        """Non-null values in the input survive the imputation pass."""
+        dirty = sample_df.copy()
+        dirty.loc[0, "age"] = None  # row 0 NULL → must be filled
+        # row 1 age=30 must be preserved even when generate emits 99
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=self._impute_decode):
+            model = self._create_model(sample_df, mock_req)
+            mock_req.side_effect = [_make_generate_response(N_ROWS)]
+            result = model.impute(dirty)
+        assert result.loc[1, "age"] == 30
+        assert result.loc[0, "age"] == 99
+
+    def test_multi_draw_calls_generate_n_times(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        dirty = sample_df.copy()
+        dirty.loc[0, "age"] = None
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=self._impute_decode):
+            model = self._create_model(sample_df, mock_req)
+            mock_req.side_effect = [_make_generate_response(N_ROWS)] * 3
+            model.impute(dirty, trials=3)
+        post_create = mock_req.call_args_list[1:]
+        assert len(post_create) == 3
+
+    def test_pick_mode_returns_modal_value(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        dirty = sample_df.copy()
+        dirty.loc[0, "age"] = None
+
+        call_count = [0]
+
+        def _decode_varied(
+            raw_codes: dict[str, Any], features: Any, column_stats: Any, **_kwargs: Any
+        ) -> pd.DataFrame:
+            n = len(next(iter(raw_codes.values())))
+            call_count[0] += 1
+            age_val = 10 if call_count[0] <= 2 else 20  # mode = 10
+            return pd.DataFrame({"age": [age_val] * n, "city": ["Z"] * n})
+
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_decode_varied):
+            model = self._create_model(sample_df, mock_req)
+            mock_req.side_effect = [_make_generate_response(N_ROWS)] * 3
+            result = model.impute(dirty, trials=3, pick="mode")
+        assert result.loc[0, "age"] == 10
+
+    def test_pick_all_returns_full_draw_list(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        dirty = sample_df.copy()
+        dirty.loc[0, "age"] = None
+
+        call_count = [0]
+
+        def _decode_seq(
+            raw_codes: dict[str, Any], features: Any, column_stats: Any, **_kwargs: Any
+        ) -> pd.DataFrame:
+            n = len(next(iter(raw_codes.values())))
+            call_count[0] += 1
+            return pd.DataFrame({"age": [call_count[0] * 10] * n, "city": ["Z"] * n})
+
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=_decode_seq):
+            model = self._create_model(sample_df, mock_req)
+            mock_req.side_effect = [_make_generate_response(N_ROWS)] * 2
+            result = model.impute(dirty, trials=2, pick="all")
+        cell = result.loc[0, "age"]
+        assert isinstance(cell, (list, np.ndarray))
+
+    def test_seed_kwarg_forwarded_to_payload(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        dirty = sample_df.copy()
+        dirty.loc[0, "age"] = None
+        with patch.object(DataxidClient, "_request") as mock_req, \
+             patch("dataxid.training._model.decode_columns", side_effect=self._impute_decode):
+            model = self._create_model(sample_df, mock_req)
+            mock_req.side_effect = [_make_generate_response(N_ROWS)]
+            model.impute(dirty, seed=42)
+        assert mock_req.call_args_list[-1][1]["json"]["seed"] == 42
+
+
+class TestErrorPropagation:
+    """The orchestration layer must let HTTP errors bubble up unmodified.
+
+    The full HTTP-status → exception-class mapping is exercised in
+    ``test_client.py``; here we only assert that ``Model`` does not catch,
+    transform, or swallow these exceptions on the user-facing path.
+    """
+
+    def test_create_propagates_authentication_error(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        with patch.object(
+            DataxidClient, "_request",
+            side_effect=AuthenticationError("Invalid API key"),
+        ):
+            with pytest.raises(AuthenticationError, match="Invalid API key"):
+                Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+
+    def test_create_propagates_invalid_request_error_with_param(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        """``InvalidRequestError.param`` must survive the propagation —
+        users rely on it to identify which field was rejected."""
+        original = InvalidRequestError("embedding_dim too large", param="embedding_dim")
+        with patch.object(DataxidClient, "_request", side_effect=original):
+            with pytest.raises(InvalidRequestError) as exc_info:
+                Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+        assert exc_info.value.param == "embedding_dim"
+
+    def test_generate_propagates_not_found_error(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        """A model deleted on the server side surfaces as ``NotFoundError``
+        on subsequent ``generate`` calls — the SDK must not retry-loop or
+        fall back."""
+        with patch.object(DataxidClient, "_request") as mock_req:
+            mock_req.side_effect = [
+                _make_create_response(),
+                NotFoundError(f"Model {MODEL_ID} not found"),
+            ]
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            with pytest.raises(NotFoundError, match="not found"):
+                model.generate()
+
+    def test_delete_propagates_not_found_error(
+        self, sample_df: pd.DataFrame, mock_train_frozen: None
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req:
+            mock_req.side_effect = [
+                _make_create_response(),
+                NotFoundError(f"Model {MODEL_ID} not found"),
+            ]
+            model = Model.create(data=sample_df, config=_DEFAULT_CONFIG)
+            with pytest.raises(NotFoundError):
+                model.delete()

--- a/tests/sdk/test_model_config.py
+++ b/tests/sdk/test_model_config.py
@@ -21,6 +21,7 @@ import pytest
 
 import dataxid
 from dataxid import Bias, Distribution, ModelConfig, Privacy, Synthetic
+from dataxid.exceptions import InvalidRequestError
 from dataxid.training._config import _resolve_config
 
 
@@ -274,21 +275,32 @@ class TestResolveConfig:
     @pytest.mark.parametrize("bad_privacy", ["a string", 42, 3.14, []])
     def test_dict_privacy_wrong_type_raises(self, bad_privacy: object) -> None:
         """Anything that is not Privacy/dict/None is rejected up-front."""
-        with pytest.raises(TypeError, match="config\\['privacy'\\]"):
+        with pytest.raises(InvalidRequestError, match="config\\['privacy'\\]") as exc_info:
             _resolve_config({"privacy": bad_privacy})
+        assert exc_info.value.param == "config"
 
     def test_model_config_returned_as_is(self) -> None:
         cfg_in = ModelConfig(embedding_dim=128, model_size="large")
         assert _resolve_config(cfg_in) is cfg_in
 
     @pytest.mark.parametrize("bad_input", ["embedding_dim=128", 42, 3.14, []])
-    def test_wrong_type_raises_type_error(self, bad_input: object) -> None:
-        with pytest.raises(TypeError, match="ModelConfig"):
+    def test_wrong_type_raises(self, bad_input: object) -> None:
+        with pytest.raises(InvalidRequestError, match="ModelConfig") as exc_info:
             _resolve_config(bad_input)  # type: ignore[arg-type]
+        assert exc_info.value.param == "config"
 
-    def test_unknown_dict_key_raises_type_error(self) -> None:
-        with pytest.raises(TypeError):
+    def test_unknown_dict_key_raises(self) -> None:
+        """Unknown keys in a dict-config surface as InvalidRequestError so
+        callers see a consistent SDK error type instead of a raw ``TypeError``
+        leaking out of ``ModelConfig.__init__``."""
+        with pytest.raises(InvalidRequestError, match="unknown field") as exc_info:
             _resolve_config({"unknown_key": 99})
+        assert exc_info.value.param == "config"
+
+    def test_unknown_privacy_dict_key_raises(self) -> None:
+        with pytest.raises(InvalidRequestError, match="config\\['privacy'\\]") as exc_info:
+            _resolve_config({"privacy": {"unknown_privacy_key": True}})
+        assert exc_info.value.param == "config"
 
 
 class TestTopLevelImport:
@@ -376,26 +388,26 @@ class TestDistributionDataclass:
             Distribution(**kwargs)
 
     @pytest.mark.parametrize(
-        "bad_key,error_type,error_match",
+        "bad_key,error_match",
         [
-            (25, TypeError, "must be strings, got int"),
-            (None, TypeError, "must be strings, got NoneType"),
-            (("a",), TypeError, "must be strings, got tuple"),
-            ("", ValueError, "non-empty / non-whitespace"),
-            ("   ", ValueError, "non-empty / non-whitespace"),
+            (25, "must be strings, got int"),
+            (None, "must be strings, got NoneType"),
+            (("a",), "must be strings, got tuple"),
+            ("", "non-empty / non-whitespace"),
+            ("   ", "non-empty / non-whitespace"),
         ],
     )
     def test_non_string_or_blank_keys_rejected(
         self,
         bad_key: object,
-        error_type: type[Exception],
         error_match: str,
     ) -> None:
         """Numeric or blank ``probabilities`` keys are rejected explicitly so
         the wire format stays consistent — server-side codes lookup uses
         ``isinstance(key, str)``, and a numeric key would silently no-op."""
-        with pytest.raises(error_type, match=error_match):
+        with pytest.raises(InvalidRequestError, match=error_match) as exc_info:
             Distribution(column="age", probabilities={bad_key: 1.0})  # type: ignore[dict-item]
+        assert exc_info.value.param == "probabilities"
 
 
 class TestBiasDataclass:

--- a/tests/sdk/test_model_config.py
+++ b/tests/sdk/test_model_config.py
@@ -1,0 +1,504 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Typed training-configuration contract.
+
+These tests pin the public surface of :class:`dataxid.ModelConfig` and the
+helper dataclasses that live next to it (:class:`dataxid.Privacy`,
+:class:`dataxid.Distribution`, :class:`dataxid.Bias`,
+:class:`dataxid.Synthetic`): defaults, field assignment, wire-format
+serialization, frozen-immutability and constructor-time validation.
+
+A small slice covers ``_resolve_config`` — the internal normalizer that
+turns ``None`` / ``dict`` / ``ModelConfig`` inputs into a single
+``ModelConfig`` instance — because it is the one place where the public
+ergonomics (accepting plain dicts) meet the typed contract.
+"""
+
+from dataclasses import FrozenInstanceError, fields
+
+import pytest
+
+import dataxid
+from dataxid import Bias, Distribution, ModelConfig, Privacy, Synthetic
+from dataxid.training._config import _resolve_config
+
+
+class TestModelConfigDefaults:
+    """ModelConfig() produces the documented default training profile."""
+
+    @pytest.mark.parametrize(
+        "field_name,expected",
+        [
+            ("embedding_dim", 64),
+            ("model_size", "medium"),
+            ("batch_size", 256),
+            ("max_epochs", 100),
+            ("early_stop_patience", 4),
+            ("val_split", 0.1),
+            ("encoding_types", None),
+            ("accumulation_steps", 1),
+            ("learning_rate", None),
+            ("label_smoothing", 0.0),
+            ("embedding_dropout", 0.5),
+            ("time_limit_seconds", 0.0),
+            ("seed", None),
+            ("timeout", 14400.0),
+        ],
+    )
+    def test_default(self, field_name: str, expected: object) -> None:
+        assert getattr(ModelConfig(), field_name) == expected
+
+    def test_privacy_default_is_privacy_instance(self) -> None:
+        assert isinstance(ModelConfig().privacy, Privacy)
+
+
+class TestPrivacyDefaults:
+    """Privacy() defaults match the documented privacy contract."""
+
+    @pytest.mark.parametrize(
+        "field_name,expected",
+        [
+            ("protect_rare", True),
+            ("rare_strategy", "mask"),
+            ("enabled", False),
+            ("noise", 0.1),
+        ],
+    )
+    def test_default(self, field_name: str, expected: object) -> None:
+        assert getattr(Privacy(), field_name) == expected
+
+    def test_each_modelconfig_gets_fresh_privacy(self) -> None:
+        """``default_factory`` prevents shared mutable state across instances."""
+        cfg_a = ModelConfig()
+        cfg_b = ModelConfig()
+        assert cfg_a.privacy is not cfg_b.privacy
+
+
+class TestPrivacyValidation:
+    """Privacy rejects malformed inputs at construction time."""
+
+    @pytest.mark.parametrize(
+        "kwargs,error_match",
+        [
+            (
+                {"rare_strategy": "invalid"},
+                "rare_strategy must be 'mask' or 'sample'",
+            ),
+            (
+                {"rare_strategy": None},
+                "rare_strategy must be 'mask' or 'sample'",
+            ),
+            ({"noise": -0.1}, "noise must be a non-negative finite"),
+            ({"noise": float("nan")}, "noise must be a non-negative finite"),
+            ({"noise": float("inf")}, "noise must be a non-negative finite"),
+            ({"noise": "loud"}, "noise must be a real number"),
+        ],
+    )
+    def test_invalid_input_rejected(
+        self, kwargs: dict, error_match: str
+    ) -> None:
+        with pytest.raises(ValueError, match=error_match):
+            Privacy(**kwargs)
+
+
+class TestModelConfigFields:
+    """Field assignment is honored verbatim by the dataclass constructor."""
+
+    @pytest.mark.parametrize(
+        "kwargs,field_name,expected",
+        [
+            ({"embedding_dim": 128}, "embedding_dim", 128),
+            ({"model_size": "small"}, "model_size", "small"),
+            ({"model_size": "large"}, "model_size", "large"),
+            ({"encoding_types": {"age": "TABULAR_NUMERIC_BINNED"}},
+             "encoding_types", {"age": "TABULAR_NUMERIC_BINNED"}),
+            ({"seed": 42}, "seed", 42),
+            ({"learning_rate": 0.001}, "learning_rate", 0.001),
+        ],
+    )
+    def test_assignment(
+        self, kwargs: dict, field_name: str, expected: object
+    ) -> None:
+        assert getattr(ModelConfig(**kwargs), field_name) == expected
+
+    def test_privacy_block_replaces_default(self) -> None:
+        privacy = Privacy(enabled=True, noise=0.5)
+        cfg = ModelConfig(privacy=privacy)
+        assert cfg.privacy.enabled is True
+        assert cfg.privacy.noise == 0.5
+
+    def test_privacy_protect_rare_false(self) -> None:
+        cfg = ModelConfig(privacy=Privacy(protect_rare=False))
+        assert cfg.privacy.protect_rare is False
+
+    def test_privacy_rare_strategy_sample(self) -> None:
+        cfg = ModelConfig(privacy=Privacy(rare_strategy="sample"))
+        assert cfg.privacy.rare_strategy == "sample"
+
+
+class TestModelConfigToDict:
+    """to_dict() is the wire format: flat dict with privacy nested as dict."""
+
+    def test_scalar_fields_round_trip(self) -> None:
+        d = ModelConfig(embedding_dim=32, model_size="small").to_dict()
+        assert d["embedding_dim"] == 32
+        assert d["model_size"] == "small"
+
+    def test_privacy_default_serialized_as_nested_dict(self) -> None:
+        d = ModelConfig().to_dict()
+        assert d["privacy"] == {
+            "protect_rare": True,
+            "rare_strategy": "mask",
+            "enabled": False,
+            "noise": 0.1,
+        }
+
+    def test_privacy_custom_values_serialized(self) -> None:
+        cfg = ModelConfig(
+            privacy=Privacy(
+                protect_rare=False,
+                rare_strategy="sample",
+                enabled=True,
+                noise=0.25,
+            )
+        )
+        assert cfg.to_dict()["privacy"] == {
+            "protect_rare": False,
+            "rare_strategy": "sample",
+            "enabled": True,
+            "noise": 0.25,
+        }
+
+    def test_none_fields_included(self) -> None:
+        d = ModelConfig().to_dict()
+        assert d["learning_rate"] is None
+        assert d["seed"] is None
+        assert d["encoding_types"] is None
+
+    def test_dict_keys_match_dataclass_fields(self) -> None:
+        """to_dict() exposes every dataclass field — no silent omission."""
+        expected = {f.name for f in fields(ModelConfig)}
+        assert set(ModelConfig().to_dict().keys()) == expected
+
+
+class TestModelConfigValidation:
+    """ModelConfig rejects out-of-range numeric inputs at construction time.
+
+    Server-side schemas (``ModelConfigSchema`` in the API) enforce the same
+    invariants; the client-side checks turn obviously wrong values into
+    immediate, local failures instead of network round-trips.
+    """
+
+    @pytest.mark.parametrize(
+        "kwargs,error_match",
+        [
+            ({"embedding_dim": 0}, "embedding_dim must be a positive integer"),
+            ({"embedding_dim": -1}, "embedding_dim must be a positive integer"),
+            ({"embedding_dim": 1.5}, "embedding_dim must be a positive integer"),
+            ({"batch_size": 0}, "batch_size must be a positive integer"),
+            ({"max_epochs": 0}, "max_epochs must be a positive integer"),
+            ({"accumulation_steps": 0}, "accumulation_steps must be a positive integer"),
+            (
+                {"early_stop_patience": -1},
+                "early_stop_patience must be a non-negative integer",
+            ),
+            ({"val_split": 0.0}, r"val_split must be in \(0, 1\)"),
+            ({"val_split": 1.0}, r"val_split must be in \(0, 1\)"),
+            ({"val_split": 1.5}, r"val_split must be in \(0, 1\)"),
+            ({"label_smoothing": -0.1}, r"label_smoothing must be in \[0, 1\)"),
+            ({"label_smoothing": 1.0}, r"label_smoothing must be in \[0, 1\)"),
+            ({"embedding_dropout": 1.0}, r"embedding_dropout must be in \[0, 1\)"),
+            (
+                {"time_limit_seconds": -1.0},
+                "time_limit_seconds must be a non-negative finite",
+            ),
+            (
+                {"time_limit_seconds": float("inf")},
+                "time_limit_seconds must be a non-negative finite",
+            ),
+            ({"timeout": 0.0}, "timeout must be a positive finite"),
+            ({"timeout": -1.0}, "timeout must be a positive finite"),
+            ({"learning_rate": 0.0}, "learning_rate must be a positive finite"),
+            ({"learning_rate": -0.001}, "learning_rate must be a positive finite"),
+            (
+                {"learning_rate": float("nan")},
+                "learning_rate must be a positive finite",
+            ),
+        ],
+    )
+    def test_invalid_input_rejected(
+        self, kwargs: dict, error_match: str
+    ) -> None:
+        with pytest.raises(ValueError, match=error_match):
+            ModelConfig(**kwargs)
+
+    def test_learning_rate_none_accepted(self) -> None:
+        """``None`` is the documented sentinel for 'auto-pick'; never rejected."""
+        assert ModelConfig(learning_rate=None).learning_rate is None
+
+
+class TestResolveConfig:
+    """_resolve_config normalizes None/dict/instance into a ModelConfig."""
+
+    def test_none_returns_defaults(self) -> None:
+        cfg = _resolve_config(None)
+        assert isinstance(cfg, ModelConfig)
+        assert cfg == ModelConfig()
+
+    def test_empty_dict_returns_defaults(self) -> None:
+        assert _resolve_config({}) == ModelConfig()
+
+    def test_dict_partial_fills_defaults(self) -> None:
+        cfg = _resolve_config({"embedding_dim": 128})
+        assert cfg.embedding_dim == 128
+        assert cfg.model_size == "medium"
+
+    def test_dict_privacy_nested_dict_promoted_to_instance(self) -> None:
+        cfg = _resolve_config({"privacy": {"enabled": True, "noise": 0.7}})
+        assert isinstance(cfg.privacy, Privacy)
+        assert cfg.privacy.enabled is True
+        assert cfg.privacy.noise == 0.7
+        assert cfg.privacy.protect_rare is True
+
+    def test_dict_privacy_instance_preserved(self) -> None:
+        privacy = Privacy(rare_strategy="sample")
+        cfg = _resolve_config({"privacy": privacy})
+        assert cfg.privacy is privacy
+
+    def test_dict_privacy_none_filled_with_defaults(self) -> None:
+        """Explicit ``None`` for privacy is replaced with a default Privacy."""
+        cfg = _resolve_config({"privacy": None})
+        assert cfg.privacy == Privacy()
+
+    @pytest.mark.parametrize("bad_privacy", ["a string", 42, 3.14, []])
+    def test_dict_privacy_wrong_type_raises(self, bad_privacy: object) -> None:
+        """Anything that is not Privacy/dict/None is rejected up-front."""
+        with pytest.raises(TypeError, match="config\\['privacy'\\]"):
+            _resolve_config({"privacy": bad_privacy})
+
+    def test_model_config_returned_as_is(self) -> None:
+        cfg_in = ModelConfig(embedding_dim=128, model_size="large")
+        assert _resolve_config(cfg_in) is cfg_in
+
+    @pytest.mark.parametrize("bad_input", ["embedding_dim=128", 42, 3.14, []])
+    def test_wrong_type_raises_type_error(self, bad_input: object) -> None:
+        with pytest.raises(TypeError, match="ModelConfig"):
+            _resolve_config(bad_input)  # type: ignore[arg-type]
+
+    def test_unknown_dict_key_raises_type_error(self) -> None:
+        with pytest.raises(TypeError):
+            _resolve_config({"unknown_key": 99})
+
+
+class TestTopLevelImport:
+    """Public dataclasses are re-exported at the package root."""
+
+    @pytest.mark.parametrize(
+        "name,obj",
+        [
+            ("ModelConfig", ModelConfig),
+            ("Privacy", Privacy),
+            ("Distribution", Distribution),
+            ("Bias", Bias),
+            ("Synthetic", Synthetic),
+        ],
+    )
+    def test_importable(self, name: str, obj: type) -> None:
+        assert getattr(dataxid, name) is obj
+
+    @pytest.mark.parametrize(
+        "name", ["ModelConfig", "Privacy", "Distribution", "Bias", "Synthetic"]
+    )
+    def test_in_all(self, name: str) -> None:
+        assert name in dataxid.__all__
+
+
+class TestDistributionDataclass:
+    """Distribution: frozen value object describing a categorical override."""
+
+    def test_basic_construction(self) -> None:
+        d = Distribution(column="gender", probabilities={"M": 0.7, "F": 0.3})
+        assert d.column == "gender"
+        assert d.probabilities == {"M": 0.7, "F": 0.3}
+
+    def test_frozen_cannot_reassign(self) -> None:
+        d = Distribution(column="gender", probabilities={"M": 0.5, "F": 0.5})
+        with pytest.raises(FrozenInstanceError):
+            d.column = "age"  # type: ignore[misc]
+
+    def test_unnormalized_probabilities_accepted(self) -> None:
+        """Probabilities are normalized downstream; raw values pass through."""
+        d = Distribution(column="gender", probabilities={"M": 2.0, "F": 3.0})
+        assert d.probabilities == {"M": 2.0, "F": 3.0}
+
+    @pytest.mark.parametrize(
+        "kwargs,error_match",
+        [
+            (
+                {"column": "", "probabilities": {"A": 1.0}},
+                "column must be a non-empty string",
+            ),
+            (
+                {"column": "   ", "probabilities": {"A": 1.0}},
+                "column must be a non-empty string",
+            ),
+            (
+                {"column": 42, "probabilities": {"A": 1.0}},
+                "column must be a non-empty string",
+            ),
+            (
+                {"column": "gender", "probabilities": {}},
+                "probabilities must be non-empty",
+            ),
+            (
+                {"column": "gender", "probabilities": {"M": -0.1, "F": 0.9}},
+                r"probabilities\['M'\] must be non-negative",
+            ),
+            (
+                {"column": "gender", "probabilities": {"M": float("nan"), "F": 0.9}},
+                r"probabilities\['M'\] must be finite",
+            ),
+            (
+                {"column": "gender", "probabilities": {"M": float("inf"), "F": 0.9}},
+                r"probabilities\['M'\] must be finite",
+            ),
+            (
+                {"column": "gender", "probabilities": {"M": "not-a-number", "F": 0.9}},
+                r"probabilities\['M'\] must be a real number",
+            ),
+        ],
+    )
+    def test_invalid_input_rejected(
+        self, kwargs: dict, error_match: str
+    ) -> None:
+        with pytest.raises(ValueError, match=error_match):
+            Distribution(**kwargs)
+
+    @pytest.mark.parametrize(
+        "bad_key,error_type,error_match",
+        [
+            (25, TypeError, "must be strings, got int"),
+            (None, TypeError, "must be strings, got NoneType"),
+            (("a",), TypeError, "must be strings, got tuple"),
+            ("", ValueError, "non-empty / non-whitespace"),
+            ("   ", ValueError, "non-empty / non-whitespace"),
+        ],
+    )
+    def test_non_string_or_blank_keys_rejected(
+        self,
+        bad_key: object,
+        error_type: type[Exception],
+        error_match: str,
+    ) -> None:
+        """Numeric or blank ``probabilities`` keys are rejected explicitly so
+        the wire format stays consistent — server-side codes lookup uses
+        ``isinstance(key, str)``, and a numeric key would silently no-op."""
+        with pytest.raises(error_type, match=error_match):
+            Distribution(column="age", probabilities={bad_key: 1.0})  # type: ignore[dict-item]
+
+
+class TestBiasDataclass:
+    """Bias: frozen value object describing statistical-parity correction."""
+
+    def test_basic_construction(self) -> None:
+        b = Bias(target="income", sensitive=["gender"])
+        assert b.target == "income"
+        assert b.sensitive == ["gender"]
+
+    def test_multi_sensitive(self) -> None:
+        b = Bias(target="income", sensitive=["gender", "race"])
+        assert b.sensitive == ["gender", "race"]
+
+    def test_frozen_cannot_reassign(self) -> None:
+        b = Bias(target="income", sensitive=["gender"])
+        with pytest.raises(FrozenInstanceError):
+            b.target = "age"  # type: ignore[misc]
+
+    @pytest.mark.parametrize(
+        "kwargs,error_match",
+        [
+            (
+                {"target": "", "sensitive": ["gender"]},
+                "target must be a non-empty string",
+            ),
+            (
+                {"target": "   ", "sensitive": ["gender"]},
+                "target must be a non-empty string",
+            ),
+            (
+                {"target": 42, "sensitive": ["gender"]},
+                "target must be a non-empty string",
+            ),
+            (
+                {"target": "income", "sensitive": []},
+                "sensitive must be a non-empty list",
+            ),
+            (
+                {"target": "income", "sensitive": ["gender", ""]},
+                "sensitive entries must be non-empty",
+            ),
+            (
+                {"target": "income", "sensitive": ["gender", "   "]},
+                "sensitive entries must be non-empty",
+            ),
+            (
+                {"target": "income", "sensitive": ["gender", "income"]},
+                "cannot appear in sensitive",
+            ),
+        ],
+    )
+    def test_invalid_input_rejected(
+        self, kwargs: dict, error_match: str
+    ) -> None:
+        with pytest.raises(ValueError, match=error_match):
+            Bias(**kwargs)
+
+
+class TestSyntheticDataclass:
+    """Synthetic: frozen generation-time tuning preset."""
+
+    def test_defaults(self) -> None:
+        s = Synthetic()
+        assert s.n is None
+        assert s.seed is None
+        assert s.diversity == 1.0
+        assert s.rare_cutoff == 1.0
+        assert s.rare_strategy is None
+
+    def test_basic_construction(self) -> None:
+        s = Synthetic(
+            n=100, seed=42, diversity=0.8, rare_cutoff=0.9, rare_strategy="mask"
+        )
+        assert s.n == 100
+        assert s.seed == 42
+        assert s.diversity == 0.8
+        assert s.rare_cutoff == 0.9
+        assert s.rare_strategy == "mask"
+
+    def test_frozen_cannot_reassign(self) -> None:
+        s = Synthetic(diversity=0.5)
+        with pytest.raises(FrozenInstanceError):
+            s.diversity = 1.0  # type: ignore[misc]
+
+    @pytest.mark.parametrize(
+        "kwargs,error_match",
+        [
+            ({"n": 0}, "n must be a positive integer"),
+            ({"n": -5}, "n must be a positive integer"),
+            ({"n": 1.5}, "n must be a positive integer"),
+            ({"diversity": 0.0}, "diversity must be > 0"),
+            ({"diversity": -0.1}, "diversity must be > 0"),
+            ({"rare_cutoff": 0.0}, r"rare_cutoff must be in \(0, 1\]"),
+            ({"rare_cutoff": 1.5}, r"rare_cutoff must be in \(0, 1\]"),
+            (
+                {"rare_strategy": "invalid"},
+                "rare_strategy must be 'mask', 'sample', or None",
+            ),
+        ],
+    )
+    def test_invalid_input_rejected(
+        self, kwargs: dict, error_match: str
+    ) -> None:
+        with pytest.raises(ValueError, match=error_match):
+            Synthetic(**kwargs)

--- a/tests/sdk/test_model_config.py
+++ b/tests/sdk/test_model_config.py
@@ -226,6 +226,10 @@ class TestModelConfigValidation:
                 {"learning_rate": float("nan")},
                 "learning_rate must be a positive finite",
             ),
+            ({"model_size": "xl"}, "model_size must be one of"),
+            ({"model_size": "MEDIUM"}, "model_size must be one of"),
+            ({"model_size": ""}, "model_size must be one of"),
+            ({"model_size": None}, "model_size must be one of"),
         ],
     )
     def test_invalid_input_rejected(
@@ -237,6 +241,73 @@ class TestModelConfigValidation:
     def test_learning_rate_none_accepted(self) -> None:
         """``None`` is the documented sentinel for 'auto-pick'; never rejected."""
         assert ModelConfig(learning_rate=None).learning_rate is None
+
+    @pytest.mark.parametrize("size", ["small", "medium", "large"])
+    def test_model_size_valid_values_accepted(self, size: str) -> None:
+        """Every documented model_size literal is accepted."""
+        assert ModelConfig(model_size=size).model_size == size
+
+    def test_invalid_model_size_param_attribute(self) -> None:
+        """The error names the offending field for programmatic handling."""
+        with pytest.raises(InvalidRequestError) as exc_info:
+            ModelConfig(model_size="xl")
+        assert exc_info.value.param == "model_size"
+
+
+class TestEncodingTypesValidation:
+    """ModelConfig.encoding_types is a typed mapping; the contract is enforced
+    at construction time so that the ``EncodingType(...)`` lookup deep inside
+    ``analyze()`` never sees an unknown value.
+    """
+
+    def test_none_is_accepted(self) -> None:
+        assert ModelConfig(encoding_types=None).encoding_types is None
+
+    def test_empty_dict_is_accepted(self) -> None:
+        assert ModelConfig(encoding_types={}).encoding_types == {}
+
+    @pytest.mark.parametrize("value", ["AUTO", "TABULAR_CATEGORICAL", "TABULAR_LAT_LONG"])
+    def test_valid_string_value_accepted(self, value: str) -> None:
+        cfg = ModelConfig(encoding_types={"col": value})
+        assert cfg.encoding_types == {"col": value}
+
+    def test_valid_enum_member_accepted(self) -> None:
+        from dataxid.encoder._ports import EncodingType
+        cfg = ModelConfig(encoding_types={"col": EncodingType.auto})
+        assert cfg.encoding_types == {"col": EncodingType.auto}
+
+    @pytest.mark.parametrize(
+        "value,error_match",
+        [
+            (["col"], "encoding_types must be a dict or None"),
+            ("AUTO", "encoding_types must be a dict or None"),
+            (42, "encoding_types must be a dict or None"),
+        ],
+    )
+    def test_non_dict_rejected(self, value: object, error_match: str) -> None:
+        with pytest.raises(InvalidRequestError, match=error_match):
+            ModelConfig(encoding_types=value)  # type: ignore[arg-type]
+
+    def test_non_string_key_rejected(self) -> None:
+        with pytest.raises(InvalidRequestError, match="keys must be strings"):
+            ModelConfig(encoding_types={1: "AUTO"})  # type: ignore[dict-item]
+
+    @pytest.mark.parametrize(
+        "value",
+        ["FANCY_TYPE", "categorical", "tabular_categorical", "auto", ""],
+    )
+    def test_unknown_string_value_rejected(self, value: str) -> None:
+        with pytest.raises(InvalidRequestError, match="must be one of"):
+            ModelConfig(encoding_types={"col": value})
+
+    def test_non_string_non_enum_value_rejected(self) -> None:
+        with pytest.raises(InvalidRequestError, match="must be one of"):
+            ModelConfig(encoding_types={"col": 42})  # type: ignore[dict-item]
+
+    def test_param_attribute_is_encoding_types(self) -> None:
+        with pytest.raises(InvalidRequestError) as exc_info:
+            ModelConfig(encoding_types={"col": "FANCY_TYPE"})
+        assert exc_info.value.param == "encoding_types"
 
 
 class TestResolveConfig:

--- a/tests/sdk/test_pk.py
+++ b/tests/sdk/test_pk.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for :mod:`dataxid._pk`, the primary-key generators used when
+synthesizing tables.
+
+Three generators are covered:
+
+* :func:`generate_dxid` — ``dxid_`` + 22 char base62 string (128 bits entropy)
+* :func:`generate_uuid` — RFC 4122 v4 UUID string
+* :func:`generate_primary_keys` — dispatch helper for ``dxid`` / ``int`` / ``uuid``
+
+Properties asserted: format invariants (prefix, length, charset), uniqueness
+under stress, and seed-determinism for the generators that draw from Python's
+global ``random`` state. The shared ``_isolate_python_rng`` fixture in
+``conftest.py`` keeps each test's seeding from leaking.
+"""
+
+import random
+import string
+import uuid
+
+import pytest
+
+from dataxid._pk import (
+    PK_TYPES,
+    PkType,
+    generate_dxid,
+    generate_primary_keys,
+    generate_uuid,
+)
+
+BASE62_ALPHABET = set(string.digits + string.ascii_uppercase + string.ascii_lowercase)
+DXID_PREFIX = "dxid_"
+DXID_BODY_LEN = 22
+DXID_TOTAL_LEN = len(DXID_PREFIX) + DXID_BODY_LEN
+
+
+class TestPkTypeConstant:
+    """``PK_TYPES`` is the wire-level enum of supported primary-key formats."""
+
+    def test_contains_expected_values(self) -> None:
+        assert set(PK_TYPES) == {"dxid", "int", "uuid"}
+
+
+class TestGenerateDxid:
+    """``generate_dxid`` — dxid format invariants and seed determinism."""
+
+    def test_format_invariants(self) -> None:
+        """Single source of truth for the dxid wire format: returns a string,
+        starts with ``dxid_``, body is exactly 22 base62 characters."""
+        result = generate_dxid()
+        assert isinstance(result, str)
+        assert result.startswith(DXID_PREFIX)
+        assert len(result) == DXID_TOTAL_LEN
+
+        body = result[len(DXID_PREFIX):]
+        assert len(body) == DXID_BODY_LEN
+        assert set(body).issubset(BASE62_ALPHABET)
+
+    def test_many_are_unique(self) -> None:
+        """Stress test: 1000 dxids in a row collide with negligible probability
+        (128-bit entropy → birthday bound ~10^19). Any collision indicates a
+        regression in the entropy source."""
+        ids = {generate_dxid() for _ in range(1000)}
+        assert len(ids) == 1000
+
+    def test_respects_random_seed(self) -> None:
+        random.seed(42)
+        a = [generate_dxid() for _ in range(5)]
+        random.seed(42)
+        b = [generate_dxid() for _ in range(5)]
+        assert a == b
+
+    def test_different_seeds_differ(self) -> None:
+        random.seed(1)
+        a = generate_dxid()
+        random.seed(2)
+        b = generate_dxid()
+        assert a != b
+
+
+class TestGenerateUuidQuirks:
+    """``generate_uuid`` deliberately draws from a separate entropy source.
+
+    Pinned here because callers must not rely on ``random.seed`` for UUID
+    determinism — that's a soft contract the module docstring promises and
+    that this test guards against accidental changes to.
+    """
+
+    def test_does_not_respect_random_seed(self) -> None:
+        random.seed(99)
+        a = generate_uuid()
+        random.seed(99)
+        b = generate_uuid()
+        assert a != b
+
+
+class TestGenerateUuid:
+    """``generate_uuid`` — UUID v4 format invariants."""
+
+    def test_returns_uuid_v4_string(self) -> None:
+        result = generate_uuid()
+        assert isinstance(result, str)
+        parsed = uuid.UUID(result)
+        assert parsed.version == 4
+
+    def test_many_are_unique(self) -> None:
+        ids = {generate_uuid() for _ in range(1000)}
+        assert len(ids) == 1000
+
+
+class TestGeneratePrimaryKeys:
+    """``generate_primary_keys`` — dispatch helper for the three pk types."""
+
+    def test_dxid_returns_list_of_dxids(self) -> None:
+        keys = generate_primary_keys("dxid", 5)
+        assert len(keys) == 5
+        assert all(isinstance(k, str) and k.startswith(DXID_PREFIX) for k in keys)
+
+    def test_int_returns_1_based_sequence(self) -> None:
+        assert generate_primary_keys("int", 4) == [1, 2, 3, 4]
+
+    def test_int_zero_returns_empty(self) -> None:
+        assert generate_primary_keys("int", 0) == []
+
+    def test_uuid_returns_list_of_uuids(self) -> None:
+        keys = generate_primary_keys("uuid", 3)
+        assert len(keys) == 3
+        for k in keys:
+            assert isinstance(k, str)
+            uuid.UUID(k)
+
+    def test_dxid_respects_random_seed(self) -> None:
+        random.seed(123)
+        a = generate_primary_keys("dxid", 10)
+        random.seed(123)
+        b = generate_primary_keys("dxid", 10)
+        assert a == b
+
+    def test_dxid_produces_unique_keys_within_batch(self) -> None:
+        keys = generate_primary_keys("dxid", 500)
+        assert len(set(keys)) == 500
+
+    @pytest.mark.parametrize("pk_type", PK_TYPES)
+    def test_length_matches_request(self, pk_type: PkType) -> None:
+        assert len(generate_primary_keys(pk_type, 7)) == 7
+
+    @pytest.mark.parametrize("pk_type", PK_TYPES)
+    def test_zero_n_returns_empty_list(self, pk_type: PkType) -> None:
+        """All three pk types treat ``n=0`` as a valid no-op rather than an error."""
+        assert generate_primary_keys(pk_type, 0) == []
+
+    def test_uuid_produces_unique_keys_within_batch(self) -> None:
+        """Symmetric to the dxid uniqueness check: UUID v4's 122-bit entropy
+        means a 500-key batch should never collide."""
+        keys = generate_primary_keys("uuid", 500)
+        assert len(set(keys)) == 500
+
+    def test_int_sequence_is_non_stateful(self) -> None:
+        """Each call restarts at 1 — there is no hidden global counter that
+        would cause cross-call key collisions in callers building multiple tables."""
+        first = generate_primary_keys("int", 3)
+        second = generate_primary_keys("int", 3)
+        assert first == second == [1, 2, 3]
+
+    def test_invalid_pk_type_raises_assertion(self) -> None:
+        """``Literal`` types are enforced statically; this guards the runtime
+        ``assert_never`` fallback against accidental removal of the dispatch arm."""
+        with pytest.raises(AssertionError):
+            generate_primary_keys("snowflake", 1)  # type: ignore[arg-type]

--- a/tests/sdk/test_quota_error.py
+++ b/tests/sdk/test_quota_error.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for :class:`dataxid.exceptions.QuotaExceededError` and its HTTP wire mapping.
+
+Quota errors are the only case where the SDK surfaces structured billing
+context (``usage``, ``upgrade_url``) on top of the standard HTTP failure,
+so this module locks down both the exception class itself and the
+``_parse_error`` routing path that builds it.
+
+Coverage:
+
+* ``QuotaExceededError`` class contract (hierarchy, attributes, defaults)
+* ``_ERROR_MAP`` directly: ``quota_exceeded`` type routes to the right class
+* ``_parse_error`` end-to-end: 402 responses with and without the ``type``
+  discriminator, with and without billing context fields
+* Pickle round-trip: custom attributes survive cross-process serialization
+"""
+
+from __future__ import annotations
+
+import pickle
+
+import httpx
+import pytest
+
+from dataxid.client._http import _ERROR_MAP, DataxidClient
+from dataxid.exceptions import APIError, DataxidError, QuotaExceededError
+
+
+def _make_response(
+    status_code: int,
+    body: dict,
+    headers: dict | None = None,
+) -> httpx.Response:
+    return httpx.Response(status_code=status_code, json=body, headers=headers or {})
+
+
+class TestQuotaExceededError:
+    """Exception class: hierarchy, custom attributes, and inherited metadata."""
+
+    def test_subclass_of_dataxid_error(self) -> None:
+        assert issubclass(QuotaExceededError, DataxidError)
+
+    def test_catchable_as_dataxid_error(self) -> None:
+        with pytest.raises(DataxidError):
+            raise QuotaExceededError("quota exceeded")
+
+    def test_usage_attribute_stored_verbatim(self) -> None:
+        """The SDK does not validate ``usage`` — it is an opaque server payload
+        passed through to the caller for display / billing logic."""
+        usage = {"used": 98_500, "limit": 100_000, "requested": 5000, "period": "2026-03"}
+        exc = QuotaExceededError("quota exceeded", usage=usage)
+        assert exc.usage == usage
+
+    def test_upgrade_url_attribute(self) -> None:
+        url = "https://example.test/checkout/pro"
+        exc = QuotaExceededError("quota exceeded", upgrade_url=url)
+        assert exc.upgrade_url == url
+
+    def test_defaults_to_none(self) -> None:
+        exc = QuotaExceededError("quota exceeded")
+        assert exc.usage is None
+        assert exc.upgrade_url is None
+
+    def test_carries_request_metadata(self) -> None:
+        """``status_code`` and ``request_id`` come from the base class — quota
+        errors must not shadow them with their custom attributes."""
+        exc = QuotaExceededError(
+            "limit reached",
+            usage={"used": 100_000},
+            upgrade_url="https://example.test/upgrade",
+            status_code=402,
+            request_id="req_abc",
+        )
+        assert exc.status_code == 402
+        assert exc.request_id == "req_abc"
+        assert str(exc) == "limit reached"
+
+
+class TestErrorMapRouting:
+    """``_ERROR_MAP`` is the wire-format ↔ exception-class lookup table."""
+
+    def test_quota_exceeded_type_routes_to_quota_exceeded_error(self) -> None:
+        assert _ERROR_MAP["quota_exceeded"] is QuotaExceededError
+
+    def test_map_contains_all_expected_types(self) -> None:
+        """Pin the full set of mapped error types so adding a new HTTP error
+        flow without touching the map is caught at review time."""
+        assert set(_ERROR_MAP) == {
+            "authentication_error",
+            "invalid_request_error",
+            "not_found_error",
+            "quota_exceeded",
+            "rate_limit_error",
+        }
+
+
+class TestParseErrorQuota:
+    """``DataxidClient._parse_error`` — 402 responses → ``QuotaExceededError``."""
+
+    def test_402_with_full_billing_context(self) -> None:
+        body = {
+            "error": {
+                "type": "quota_exceeded",
+                "code": "free_tier_limit_reached",
+                "message": "Monthly free tier limit exceeded.",
+                "usage": {
+                    "used": 100_000, "limit": 100_000,
+                    "requested": 5000, "period": "2026-03",
+                },
+                "upgrade_url": "https://example.test/checkout/pro",
+            }
+        }
+        exc = DataxidClient._parse_error(_make_response(402, body))
+
+        assert isinstance(exc, QuotaExceededError)
+        assert exc.status_code == 402
+        assert exc.usage == body["error"]["usage"]
+        assert exc.upgrade_url == body["error"]["upgrade_url"]
+        assert str(exc) == "Monthly free tier limit exceeded."
+
+    def test_402_without_billing_context_still_routes(self) -> None:
+        """Servers that signal ``type=quota_exceeded`` but omit ``usage`` /
+        ``upgrade_url`` still produce a ``QuotaExceededError`` — the optional
+        fields default to ``None`` rather than raising on the parse path."""
+        body = {"error": {"type": "quota_exceeded", "message": "Upgrade to continue."}}
+        exc = DataxidClient._parse_error(_make_response(402, body))
+
+        assert isinstance(exc, QuotaExceededError)
+        assert exc.usage is None
+        assert exc.upgrade_url is None
+        assert str(exc) == "Upgrade to continue."
+
+    def test_402_without_type_falls_back_to_api_error(self) -> None:
+        """The discriminator is the ``type`` field, not the status code:
+        a 402 response missing ``type`` must surface as the generic
+        ``APIError`` so the caller does not assume billing context exists."""
+        body = {"error": {"message": "Payment Required"}}
+        exc = DataxidClient._parse_error(_make_response(402, body))
+
+        assert isinstance(exc, APIError)
+        assert not isinstance(exc, QuotaExceededError)
+
+
+class TestPickleRoundTrip:
+    """Cross-process safety: custom attributes survive ``pickle.dumps`` / ``loads``.
+
+    Users of multi-process executors (Dask, Ray, joblib) regularly pickle
+    raised exceptions; losing ``usage`` / ``upgrade_url`` would break their
+    error-handling code without an obvious failure mode.
+    """
+
+    def test_attributes_round_trip(self) -> None:
+        original = QuotaExceededError(
+            "quota exceeded",
+            usage={"used": 100_000, "limit": 100_000},
+            upgrade_url="https://example.test/upgrade",
+            status_code=402,
+            request_id="req_pickled",
+        )
+        restored = pickle.loads(pickle.dumps(original))
+
+        assert isinstance(restored, QuotaExceededError)
+        assert restored.usage == original.usage
+        assert restored.upgrade_url == original.upgrade_url
+        assert restored.status_code == 402
+        assert restored.request_id == "req_pickled"
+        assert str(restored) == str(original)

--- a/tests/sdk/test_serialization.py
+++ b/tests/sdk/test_serialization.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for :mod:`dataxid.client._serialization`, the SDK's wire-format codec.
+
+Two payload families are covered:
+
+* **Embeddings** — :func:`serialize_embedding` / :func:`deserialize_embedding`
+  for the ``numpy-b64`` (current) and ``json-flat`` (legacy) encodings, with
+  auto-detection on the deserialize side so older servers stay compatible.
+* **Encoder state** — :func:`serialize_encoder_state` /
+  :func:`deserialize_encoder_state` checkpoint helpers used by the frozen
+  training loop to ship encoder weights through the API.
+
+Properties asserted: bidirectional equality on roundtrip, format auto-detection,
+defaulted fields (``dtype``, ``encoding``), shape edge cases (scalar, empty,
+high-rank), and gradient detachment.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+
+from dataxid.client._serialization import (
+    ENCODING_JSON_FLAT,
+    ENCODING_NUMPY_B64,
+    deserialize_embedding,
+    deserialize_encoder_state,
+    serialize_embedding,
+    serialize_encoder_state,
+)
+
+
+class TestSerializeEmbedding:
+    """Wire-format invariants for ``serialize_embedding``."""
+
+    def test_payload_has_self_describing_fields(self) -> None:
+        """The payload must carry every field a fresh deserializer needs:
+        encoding tag, dtype, shape, and the b64 body."""
+        payload = serialize_embedding(torch.randn(10, 64))
+        assert payload["encoding"] == ENCODING_NUMPY_B64
+        assert payload["dtype"] == "float32"
+        assert payload["shape"] == [10, 64]
+        assert isinstance(payload["embedding_b64"], str)
+
+    @pytest.mark.parametrize(
+        "tensor",
+        [
+            torch.randn(64),         # 1D
+            torch.randn(4, 8),       # 2D
+            torch.randn(2, 3, 4),    # 3D
+            torch.tensor(3.14),      # scalar
+            torch.empty(0),          # empty
+        ],
+        ids=["1d", "2d", "3d", "scalar", "empty"],
+    )
+    def test_shape_preserved(self, tensor: torch.Tensor) -> None:
+        payload = serialize_embedding(tensor)
+        assert payload["shape"] == list(tensor.shape)
+
+    def test_detaches_gradient(self) -> None:
+        """A tensor with ``requires_grad=True`` would crash ``.numpy()`` if
+        the implementation did not call ``.detach()``. Reaching the assert
+        therefore proves detachment happened."""
+        t = torch.randn(4, 8, requires_grad=True)
+        payload = serialize_embedding(t)
+        restored = deserialize_embedding(payload)
+        assert restored.requires_grad is False
+
+
+class TestDeserializeEmbedding:
+    """Wire-format ingestion + auto-detection for ``deserialize_embedding``."""
+
+    def test_numpy_b64_roundtrip_preserves_values(self) -> None:
+        original = torch.randn(10, 64)
+        restored = deserialize_embedding(serialize_embedding(original))
+        assert restored.shape == original.shape
+        assert restored.dtype == torch.float32
+        torch.testing.assert_close(restored, original, atol=1e-6, rtol=1e-6)
+
+    def test_legacy_list_input_full_value_match(self) -> None:
+        """Legacy callers pass a raw nested list — every element must be
+        preserved with float32 precision, not just the shape."""
+        data = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        result = deserialize_embedding(data)
+        assert result.shape == (2, 3)
+        torch.testing.assert_close(
+            result, torch.tensor(data, dtype=torch.float32), atol=1e-6, rtol=1e-6,
+        )
+
+    def test_legacy_json_flat_dict_full_value_match(self) -> None:
+        """Same legacy contract, this time wrapped in the ``json-flat`` envelope."""
+        data = [[1.0, 2.0], [3.0, 4.0]]
+        payload = {"data": data, "encoding": ENCODING_JSON_FLAT}
+        result = deserialize_embedding(payload)
+        torch.testing.assert_close(
+            result, torch.tensor(data, dtype=torch.float32), atol=1e-6, rtol=1e-6,
+        )
+
+    def test_dtype_field_is_optional(self) -> None:
+        """A payload missing ``dtype`` must default to float32, otherwise
+        older servers that emit shape+b64 only would break."""
+        arr = np.array([[1.0, 2.0]], dtype=np.float32)
+        payload = {
+            "embedding_b64": base64.b64encode(arr.tobytes()).decode("ascii"),
+            "shape": [1, 2],
+            "encoding": ENCODING_NUMPY_B64,
+        }
+        result = deserialize_embedding(payload)
+        assert result.dtype == torch.float32
+        torch.testing.assert_close(
+            result, torch.tensor(arr, dtype=torch.float32), atol=1e-6, rtol=1e-6,
+        )
+
+    def test_encoding_field_is_optional_defaults_to_json_flat(self) -> None:
+        """Pre-encoding-tag payloads (no ``encoding`` field) must be treated
+        as legacy ``json-flat`` rather than rejected — protects backward
+        compatibility with older API responses."""
+        result = deserialize_embedding({"data": [[1.0, 2.0]]})
+        torch.testing.assert_close(
+            result, torch.tensor([[1.0, 2.0]], dtype=torch.float32), atol=1e-6, rtol=1e-6,
+        )
+
+    def test_default_device_is_cpu(self) -> None:
+        result = deserialize_embedding(serialize_embedding(torch.randn(3, 8)))
+        assert result.device.type == "cpu"
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(),
+        reason="cuda not available in this environment",
+    )
+    def test_device_parameter_routes_to_cuda(self) -> None:
+        result = deserialize_embedding(
+            serialize_embedding(torch.randn(3, 8)), device="cuda",
+        )
+        assert result.device.type == "cuda"
+
+    def test_unknown_encoding_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Unknown embedding encoding"):
+            deserialize_embedding({"encoding": "arrow-v99"})
+
+
+class TestCrossFormatConsistency:
+    """The same logical tensor must compare equal across both wire encodings.
+
+    Pinning this prevents a future codec tweak from silently introducing a
+    precision mismatch between the two paths.
+    """
+
+    def test_numpy_b64_matches_json_flat_for_same_tensor(self) -> None:
+        original = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
+        from_b64 = deserialize_embedding(
+            serialize_embedding(torch.tensor(original, dtype=torch.float32))
+        )
+        from_legacy = deserialize_embedding(original)
+        torch.testing.assert_close(from_b64, from_legacy, atol=1e-6, rtol=1e-6)
+
+
+class _MockBackend:
+    """Minimal stand-in for the encoder backend used by the checkpoint helpers.
+
+    The real backend wraps a much larger module, but the checkpoint contract
+    only reads ``backend.encoder.state_dict()`` — so any ``nn.Module``
+    behind ``.encoder`` is enough to exercise the roundtrip.
+    """
+
+    def __init__(self, in_features: int = 4, out_features: int = 8) -> None:
+        self.encoder = torch.nn.Linear(in_features, out_features)
+
+
+def _adamw(backend: _MockBackend) -> torch.optim.AdamW:
+    return torch.optim.AdamW(backend.encoder.parameters(), lr=0.01)
+
+
+class TestEncoderStateRoundTrip:
+    """Checkpoint helpers — frozen-training relies on a lossless save/load cycle."""
+
+    def test_serialize_returns_bytes(self) -> None:
+        backend = _MockBackend()
+        data = serialize_encoder_state(backend, _adamw(backend))
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+
+    def test_deserialize_restores_weights_exactly(self) -> None:
+        """Trained weights must come back bit-identical — any drift would
+        invalidate the encoder mid-training."""
+        original = _MockBackend()
+        data = serialize_encoder_state(original, _adamw(original))
+
+        restored = _MockBackend()
+        deserialize_encoder_state(data, restored, _adamw(restored))
+
+        for p1, p2 in zip(
+            original.encoder.parameters(), restored.encoder.parameters(), strict=True
+        ):
+            assert torch.equal(p1, p2)
+
+    def test_deserialize_restores_optimizer_state(self) -> None:
+        """The optimizer's running statistics (Adam's m, v) survive the
+        roundtrip after a step has been taken — without this, training
+        could not be paused and resumed."""
+        original = _MockBackend()
+        original_opt = _adamw(original)
+
+        # Take one step so the optimizer has live state to serialize.
+        loss = original.encoder(torch.randn(2, 4)).sum()
+        loss.backward()
+        original_opt.step()
+
+        data = serialize_encoder_state(original, original_opt)
+
+        restored = _MockBackend()
+        restored.encoder.load_state_dict(original.encoder.state_dict())
+        restored_opt = _adamw(restored)
+        deserialize_encoder_state(data, restored, restored_opt)
+
+        original_state = original_opt.state_dict()["state"]
+        restored_state = restored_opt.state_dict()["state"]
+        assert original_state.keys() == restored_state.keys()
+        for key in original_state:
+            for field, value in original_state[key].items():
+                if isinstance(value, torch.Tensor):
+                    assert torch.equal(value, restored_state[key][field])
+                else:
+                    assert value == restored_state[key][field]
+
+    def test_deserialize_mutates_in_place(self) -> None:
+        """The helper returns ``None`` and mutates the supplied backend +
+        optimizer; callers rely on this to thread state through."""
+        original = _MockBackend()
+        data = serialize_encoder_state(original, _adamw(original))
+
+        restored = _MockBackend()
+        opt = _adamw(restored)
+        result: Any = deserialize_encoder_state(data, restored, opt)
+        assert result is None

--- a/tests/sdk/test_synthesize_tables.py
+++ b/tests/sdk/test_synthesize_tables.py
@@ -1,0 +1,1377 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for :func:`dataxid.synthesize_tables` and the supporting machinery in
+:mod:`dataxid._table`.
+
+The orchestrator coordinates multi-table synthesis by:
+
+* validating the :class:`~dataxid.Table` graph (FK targets, cycles, sequencing
+  constraints),
+* topologically sorting tables so parents are generated before children,
+* dispatching root tables to :func:`dataxid.synthesize` and child tables to
+  :meth:`dataxid.Model.create` / ``Model.generate``,
+* assigning synthetic primary keys (:func:`_assign_primary_keys`) and remapping
+  foreign keys to maintain referential integrity (:func:`_remap_foreign_keys`).
+
+All API entry points are mocked; no network calls or real training occurs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+import dataxid
+from dataxid import Distribution, ModelConfig, Table
+from dataxid._table import (
+    _assign_primary_keys,
+    _remap_foreign_keys,
+    _topological_sort,
+    _validate_tables,
+)
+from dataxid.exceptions import InvalidRequestError
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def accounts_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "account_id": [101, 102, 103],
+            "district": ["A", "B", "A"],
+            "balance": [1000, 2000, 1500],
+        }
+    )
+
+
+@pytest.fixture()
+def transactions_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "account_id": [101, 101, 102, 103, 103],
+            "amount": [100.0, 200.0, 300.0, 50.0, 75.0],
+            "type": ["credit", "debit", "credit", "credit", "debit"],
+        }
+    )
+
+
+@pytest.fixture()
+def _api_key() -> Iterator[None]:
+    """Set a dummy API key for orchestrator tests; restore after."""
+    original = dataxid.api_key
+    dataxid.api_key = "dx_test_synthesize_tables"
+    try:
+        yield
+    finally:
+        dataxid.api_key = original
+
+
+def _make_fake_df(
+    data: pd.DataFrame,
+    n: int,
+    parent: pd.DataFrame | None = None,
+    parent_key: str | None = None,
+    foreign_key: str | None = None,
+) -> pd.DataFrame:
+    """Build a synthetic DataFrame mirroring ``data``'s column structure.
+
+    Numeric columns are filled with ``range(n)``; categorical columns cycle
+    through observed values. When ``parent`` and FK info are supplied, the
+    FK column is filled by cycling the parent's PK values, guaranteeing
+    referential integrity in tests that rely on it.
+    """
+    result: dict[str, list[Any]] = {}
+    for col in data.columns:
+        if pd.api.types.is_numeric_dtype(data[col]):
+            result[col] = list(range(n))
+        else:
+            vals = data[col].unique().tolist()
+            result[col] = [vals[i % len(vals)] for i in range(n)]
+
+    if foreign_key and parent is not None and parent_key:
+        pk_values = parent[parent_key].values
+        result[foreign_key] = [pk_values[i % len(pk_values)] for i in range(n)]
+
+    return pd.DataFrame(result)
+
+
+def _mock_synthesize(
+    data: pd.DataFrame,
+    n_samples: int | None = None,
+    parent: pd.DataFrame | None = None,
+    **kwargs: Any,
+) -> pd.DataFrame:
+    """Stand-in for :func:`dataxid.synthesize` (root / flat tables)."""
+    n = n_samples or (len(parent) if parent is not None else len(data))
+    return _make_fake_df(
+        data, n, parent, kwargs.get("parent_key"), kwargs.get("foreign_key")
+    )
+
+
+def _mock_model_create(
+    data: pd.DataFrame,
+    parent: pd.DataFrame | None = None,
+    foreign_key: str | None = None,
+    parent_key: str | None = None,
+    **kwargs: Any,
+) -> MagicMock:
+    """Stand-in for :meth:`dataxid.Model.create` (sequential child tables)."""
+    mock_model = MagicMock()
+    mock_model.id = "mdl_test_mock"
+
+    captured = {
+        "data": data,
+        "parent": parent,
+        "foreign_key": foreign_key,
+        "parent_key": parent_key,
+    }
+
+    def _generate(parent: pd.DataFrame | None = None, **kw: Any) -> pd.DataFrame:
+        cd = parent if parent is not None else captured["parent"]
+        n = len(cd) if cd is not None else len(captured["data"])
+        return _make_fake_df(
+            captured["data"], n, cd, captured["parent_key"], captured["foreign_key"]
+        )
+
+    mock_model.generate = _generate
+    mock_model.delete = MagicMock()
+    return mock_model
+
+
+@contextmanager
+def _mock_synthesize_stack(
+    synthesize_side_effect: Any = _mock_synthesize,
+    create_side_effect: Any = _mock_model_create,
+) -> Iterator[None]:
+    """Patch both :func:`dataxid.synthesize` and :meth:`Model.create` together."""
+    with (
+        patch("dataxid.synthesize", side_effect=synthesize_side_effect),
+        patch("dataxid.Model.create", side_effect=create_side_effect),
+    ):
+        yield
+
+
+def _make_capturing_create(
+    create_calls: list[dict[str, Any]] | None = None,
+    generate_calls: list[dict[str, Any]] | None = None,
+) -> Any:
+    """Factory: a ``Model.create`` side_effect that records call kwargs.
+
+    Pass ``create_calls`` to capture ``Model.create`` invocations and / or
+    ``generate_calls`` to capture the resulting model's ``generate`` calls.
+    Either list may be ``None`` to skip recording.
+    """
+
+    def _side_effect(
+        data: pd.DataFrame,
+        parent: pd.DataFrame | None = None,
+        **kwargs: Any,
+    ) -> MagicMock:
+        if create_calls is not None:
+            create_calls.append({"data": data, "parent": parent, **kwargs})
+        mock_model = _mock_model_create(data, parent=parent, **kwargs)
+
+        if generate_calls is not None:
+            original_generate = mock_model.generate
+
+            def _capture_generate(**kw: Any) -> pd.DataFrame:
+                generate_calls.append(kw)
+                return original_generate(**kw)
+
+            mock_model.generate = _capture_generate
+        return mock_model
+
+    return _side_effect
+
+
+def _make_capturing_synthesize(
+    synth_calls: list[dict[str, Any]],
+) -> Any:
+    """Factory: a ``synthesize`` side_effect that records call kwargs."""
+
+    def _side_effect(data: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:
+        synth_calls.append(kwargs)
+        return _mock_synthesize(data, **kwargs)
+
+    return _side_effect
+
+
+# ---------------------------------------------------------------------------
+# Table dataclass validation
+# ---------------------------------------------------------------------------
+
+
+class TestTableValidation:
+    """Field-level invariants of the :class:`~dataxid.Table` dataclass."""
+
+    def test_valid_table(self, accounts_df: pd.DataFrame) -> None:
+        tbl = Table(accounts_df, primary_key="account_id")
+        assert tbl.primary_key == "account_id"
+
+    def test_data_must_be_dataframe(self) -> None:
+        with pytest.raises(InvalidRequestError, match="must be a DataFrame"):
+            Table("not_a_dataframe")
+
+    def test_primary_key_must_exist(self, accounts_df: pd.DataFrame) -> None:
+        with pytest.raises(InvalidRequestError, match="not found"):
+            Table(accounts_df, primary_key="nonexistent")
+
+    def test_fk_column_must_exist(self, accounts_df: pd.DataFrame) -> None:
+        parent = Table(accounts_df, primary_key="account_id")
+        with pytest.raises(InvalidRequestError, match="Foreign key column"):
+            Table(accounts_df, foreign_keys={"nonexistent": parent})
+
+    def test_fk_value_must_be_table(self, accounts_df: pd.DataFrame) -> None:
+        with pytest.raises(InvalidRequestError, match="must be Table instances"):
+            Table(accounts_df, foreign_keys={"account_id": "accounts"})
+
+    def test_fk_parent_must_have_pk(self, accounts_df: pd.DataFrame) -> None:
+        parent_no_pk = Table(accounts_df)
+        with pytest.raises(InvalidRequestError, match="must have a primary_key"):
+            Table(accounts_df, foreign_keys={"account_id": parent_no_pk})
+
+    def test_foreign_keys_default_empty(self, accounts_df: pd.DataFrame) -> None:
+        tbl = Table(accounts_df)
+        assert tbl.foreign_keys == {}
+
+    def test_positional_data(self, accounts_df: pd.DataFrame) -> None:
+        tbl = Table(accounts_df)
+        assert len(tbl.data) == 3
+
+    def test_sequential_default_true(self, accounts_df: pd.DataFrame) -> None:
+        tbl = Table(accounts_df)
+        assert tbl.sequential is True
+
+    def test_sequence_by_must_be_in_foreign_keys(
+        self, accounts_df: pd.DataFrame
+    ) -> None:
+        parent = Table(accounts_df, primary_key="account_id")
+        with pytest.raises(InvalidRequestError, match="must be one of the foreign_keys"):
+            Table(
+                accounts_df,
+                foreign_keys={"account_id": parent},
+                sequence_by="nonexistent",
+            )
+
+    def test_sequence_by_and_sequential_false_mutually_exclusive(
+        self, accounts_df: pd.DataFrame
+    ) -> None:
+        parent = Table(accounts_df, primary_key="account_id")
+        with pytest.raises(InvalidRequestError, match="mutually exclusive"):
+            Table(
+                accounts_df,
+                foreign_keys={"account_id": parent},
+                sequential=False,
+                sequence_by="account_id",
+            )
+
+    def test_multi_fk_requires_sequence_by(self) -> None:
+        df = pd.DataFrame(
+            {
+                "customer_id": [1, 2, 3],
+                "product_id": [10, 20, 30],
+                "amount": [100, 200, 300],
+            }
+        )
+        customers = Table(
+            pd.DataFrame({"customer_id": [1, 2, 3]}), primary_key="customer_id"
+        )
+        products = Table(
+            pd.DataFrame({"product_id": [10, 20, 30]}), primary_key="product_id"
+        )
+        with pytest.raises(InvalidRequestError, match="sequence_by"):
+            Table(df, foreign_keys={"customer_id": customers, "product_id": products})
+
+    def test_multi_fk_with_sequence_by_ok(self) -> None:
+        df = pd.DataFrame(
+            {
+                "customer_id": [1, 2, 3],
+                "product_id": [10, 20, 30],
+                "amount": [100, 200, 300],
+            }
+        )
+        customers = Table(
+            pd.DataFrame({"customer_id": [1, 2, 3]}), primary_key="customer_id"
+        )
+        products = Table(
+            pd.DataFrame({"product_id": [10, 20, 30]}), primary_key="product_id"
+        )
+        tbl = Table(
+            df,
+            foreign_keys={"customer_id": customers, "product_id": products},
+            sequence_by="customer_id",
+        )
+        assert tbl.sequence_by == "customer_id"
+
+
+class TestTablePkType:
+    """``Table.pk_type`` — accepted values and storage semantics."""
+
+    def test_default_is_dxid(self, accounts_df: pd.DataFrame) -> None:
+        tbl = Table(accounts_df, primary_key="account_id")
+        assert tbl.pk_type == "dxid"
+
+    @pytest.mark.parametrize("pk_type", ["dxid", "int", "uuid"])
+    def test_accepts_valid_types(
+        self, accounts_df: pd.DataFrame, pk_type: str
+    ) -> None:
+        tbl = Table(accounts_df, primary_key="account_id", pk_type=pk_type)
+        assert tbl.pk_type == pk_type
+
+    def test_invalid_pk_type_rejected(self, accounts_df: pd.DataFrame) -> None:
+        with pytest.raises(InvalidRequestError, match="pk_type must be one of"):
+            Table(accounts_df, primary_key="account_id", pk_type="snowflake")
+
+    def test_pk_type_valid_without_primary_key(
+        self, accounts_df: pd.DataFrame
+    ) -> None:
+        """``pk_type`` is stored even when ``primary_key`` is None — unused
+        but must not raise."""
+        tbl = Table(accounts_df, pk_type="int")
+        assert tbl.pk_type == "int"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — _validate_tables / _topological_sort
+# ---------------------------------------------------------------------------
+
+
+class TestValidateTables:
+    """Cross-table validation (FK targets, cycles)."""
+
+    def test_empty_tables(self) -> None:
+        with pytest.raises(InvalidRequestError, match="at least one"):
+            _validate_tables({})
+
+    def test_fk_target_not_in_tables(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        orphan_parent = Table(accounts_df, primary_key="account_id")
+        child = Table(transactions_df, foreign_keys={"account_id": orphan_parent})
+        with pytest.raises(InvalidRequestError, match="not in the tables dict"):
+            _validate_tables({"transactions": child})
+
+    def test_valid_two_tables(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        acct = Table(accounts_df, primary_key="account_id")
+        _validate_tables(
+            {
+                "accounts": acct,
+                "transactions": Table(
+                    transactions_df, foreign_keys={"account_id": acct}
+                ),
+            }
+        )
+
+    def test_circular_dependency(self, accounts_df: pd.DataFrame) -> None:
+        a = Table(accounts_df, primary_key="account_id")
+        b = Table(accounts_df, primary_key="account_id")
+        # Bypass __post_init__ to wire a cycle that the dataclass would reject.
+        object.__setattr__(a, "foreign_keys", {"district": b})
+        object.__setattr__(b, "foreign_keys", {"district": a})
+        with pytest.raises(InvalidRequestError, match="Circular dependency"):
+            _validate_tables({"a": a, "b": b})
+
+
+class TestTopologicalSort:
+    """Parents before children; cycles return ``None``."""
+
+    def test_single_table(self, accounts_df: pd.DataFrame) -> None:
+        tables = {"accounts": Table(accounts_df, primary_key="account_id")}
+        assert _topological_sort(tables) == ["accounts"]
+
+    def test_parent_before_child(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        acct = Table(accounts_df, primary_key="account_id")
+        tables = {
+            "transactions": Table(
+                transactions_df, foreign_keys={"account_id": acct}
+            ),
+            "accounts": acct,
+        }
+        order = _topological_sort(tables)
+        assert order is not None
+        assert order.index("accounts") < order.index("transactions")
+
+    def test_cycle_returns_none(self, accounts_df: pd.DataFrame) -> None:
+        a = Table(accounts_df, primary_key="account_id")
+        b = Table(accounts_df, primary_key="account_id")
+        object.__setattr__(a, "foreign_keys", {"district": b})
+        object.__setattr__(b, "foreign_keys", {"district": a})
+        assert _topological_sort({"a": a, "b": b}) is None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — _assign_primary_keys / _remap_foreign_keys
+# ---------------------------------------------------------------------------
+
+
+class TestAssignPrimaryKeys:
+    """Synthetic PK assignment after generation."""
+
+    def test_inserts_first_column(self) -> None:
+        df = pd.DataFrame({"name": ["Alice", "Bob", "Carol"]})
+        result = _assign_primary_keys(df, "id")
+        assert list(result.columns) == ["id", "name"]
+
+    def test_default_pk_type_is_dxid(self) -> None:
+        df = pd.DataFrame({"x": [10, 20, 30]})
+        result = _assign_primary_keys(df, "pk")
+        assert all(isinstance(v, str) and v.startswith("dxid_") for v in result["pk"])
+
+    def test_int_pk_type_one_based_increment(self) -> None:
+        df = pd.DataFrame({"x": [10, 20, 30]})
+        result = _assign_primary_keys(df, "pk", pk_type="int")
+        assert list(result["pk"]) == [1, 2, 3]
+
+    def test_uuid_pk_type_returns_uuid_strings(self) -> None:
+        import uuid as _uuid
+
+        df = pd.DataFrame({"x": [1, 2]})
+        result = _assign_primary_keys(df, "pk", pk_type="uuid")
+        for v in result["pk"]:
+            assert isinstance(v, str)
+            _uuid.UUID(v)
+
+    def test_does_not_mutate_original(self) -> None:
+        df = pd.DataFrame({"x": [1]})
+        _assign_primary_keys(df, "pk")
+        assert "pk" not in df.columns
+
+
+class TestRemapForeignKeys:
+    """FK remap preserves referential integrity to a synthetic parent."""
+
+    def test_no_orphans_no_change(self) -> None:
+        parent = pd.DataFrame({"pk": [1, 2, 3]})
+        child = pd.DataFrame({"fk": [1, 2, 3, 1]})
+        result = _remap_foreign_keys(child, "fk", parent, "pk")
+        assert list(result["fk"]) == [1, 2, 3, 1]
+
+    def test_orphans_remapped(self) -> None:
+        parent = pd.DataFrame({"pk": [1, 2]})
+        child = pd.DataFrame({"fk": [1, 999, 888]})
+        result = _remap_foreign_keys(child, "fk", parent, "pk")
+        assert set(result["fk"]).issubset({1, 2})
+
+    def test_does_not_mutate_original(self) -> None:
+        parent = pd.DataFrame({"pk": [1]})
+        child = pd.DataFrame({"fk": [999]})
+        _remap_foreign_keys(child, "fk", parent, "pk")
+        assert child["fk"].iloc[0] == 999
+
+
+# ---------------------------------------------------------------------------
+# synthesize_tables — full orchestration (2-table)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_api_key")
+class TestSynthesizeTables:
+    """End-to-end orchestration over a parent → child pair."""
+
+    def test_return_shape_contract(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        """Returns ``dict[name -> DataFrame]`` keyed by the input tables."""
+        acct = Table(accounts_df, primary_key="account_id")
+        with _mock_synthesize_stack():
+            result = dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                }
+            )
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"accounts", "transactions"}
+        assert all(isinstance(df, pd.DataFrame) for df in result.values())
+
+    def test_pk_auto_assigned(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        acct = Table(accounts_df, primary_key="account_id", pk_type="int")
+        with _mock_synthesize_stack():
+            result = dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                }
+            )
+        syn_accounts = result["accounts"]
+        assert "account_id" in syn_accounts.columns
+        assert syn_accounts["account_id"].is_unique
+        assert list(syn_accounts["account_id"]) == [1, 2, 3]
+
+    def test_pk_excluded_from_training(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        """The PK column must be stripped before sending data for training,
+        otherwise the model would learn meaningless ID statistics."""
+        acct = Table(accounts_df, primary_key="account_id")
+        synth_calls: list[dict[str, Any]] = []
+
+        def _capture(data: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:
+            synth_calls.append({"columns": list(data.columns), "kwargs": kwargs})
+            return _mock_synthesize(data, **kwargs)
+
+        with _mock_synthesize_stack(synthesize_side_effect=_capture):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                }
+            )
+
+        assert "account_id" not in synth_calls[0]["columns"]
+
+    def test_referential_integrity(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        acct = Table(accounts_df, primary_key="account_id")
+        with _mock_synthesize_stack():
+            result = dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                }
+            )
+        syn_acct_ids = set(result["accounts"]["account_id"])
+        syn_trans_ids = set(result["transactions"]["account_id"])
+        orphans = syn_trans_ids - syn_acct_ids
+        assert len(orphans) == 0, f"Orphan FK values: {orphans}"
+
+    def test_single_root_table(self, accounts_df: pd.DataFrame) -> None:
+        with _mock_synthesize_stack():
+            result = dataxid.synthesize_tables(
+                {"accounts": Table(accounts_df, primary_key="account_id")}
+            )
+        assert "accounts" in result
+        assert "account_id" in result["accounts"].columns
+
+    def test_table_without_pk(self, accounts_df: pd.DataFrame) -> None:
+        df = accounts_df.drop(columns=["account_id"])
+        with _mock_synthesize_stack():
+            result = dataxid.synthesize_tables({"data": Table(df)})
+        assert "data" in result
+        assert len(result["data"]) == len(df)
+
+    def test_child_uses_real_parent_for_training(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        """Training context uses the real parent rows; only generation
+        switches to the synthetic parent."""
+        acct = Table(accounts_df, primary_key="account_id")
+        create_calls: list[dict[str, Any]] = []
+
+        with _mock_synthesize_stack(
+            create_side_effect=_make_capturing_create(create_calls=create_calls)
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                }
+            )
+
+        assert len(create_calls) == 1
+        ctx_used = create_calls[0]["parent"]
+        assert list(ctx_used["account_id"]) == [101, 102, 103]
+
+    def test_child_generates_with_synthetic_parent(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        acct = Table(accounts_df, primary_key="account_id", pk_type="int")
+        generate_calls: list[dict[str, Any]] = []
+
+        with _mock_synthesize_stack(
+            create_side_effect=_make_capturing_create(generate_calls=generate_calls)
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                }
+            )
+
+        assert len(generate_calls) == 1
+        syn_parent = generate_calls[0]["parent"]
+        assert list(syn_parent["account_id"]) == [1, 2, 3]
+
+    def test_non_sequential_uses_flat_plus_remap(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        """``foreign_keys`` + ``sequential=False`` → flat ``synthesize`` for
+        both tables, FK column remapped post-hoc for referential integrity."""
+        acct = Table(accounts_df, primary_key="account_id")
+        synthesize_calls: list[dict[str, Any]] = []
+
+        with _mock_synthesize_stack(
+            synthesize_side_effect=_make_capturing_synthesize(synthesize_calls)
+        ):
+            result = dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df,
+                        foreign_keys={"account_id": acct},
+                        sequential=False,
+                    ),
+                }
+            )
+
+        assert len(synthesize_calls) == 2
+        syn_acct_ids = set(result["accounts"]["account_id"])
+        syn_trans_ids = set(result["transactions"]["account_id"])
+        assert syn_trans_ids.issubset(syn_acct_ids)
+
+
+# ---------------------------------------------------------------------------
+# sequence_by — N-parent disambiguation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_api_key")
+class TestSequenceBy:
+    """Multi-FK child uses ``sequence_by`` to pick its sequential parent."""
+
+    def test_sequence_by_selects_correct_parent(self) -> None:
+        df = pd.DataFrame(
+            {
+                "customer_id": [1, 2, 3],
+                "product_id": [10, 20, 30],
+                "amount": [100, 200, 300],
+            }
+        )
+        customers = Table(
+            pd.DataFrame({"customer_id": [1, 2, 3], "name": ["A", "B", "C"]}),
+            primary_key="customer_id",
+        )
+        products = Table(
+            pd.DataFrame(
+                {"product_id": [10, 20, 30], "category": ["X", "Y", "Z"]}
+            ),
+            primary_key="product_id",
+        )
+        create_calls: list[dict[str, Any]] = []
+
+        with _mock_synthesize_stack(
+            create_side_effect=_make_capturing_create(create_calls=create_calls)
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "customers": customers,
+                    "products": products,
+                    "orders": Table(
+                        df,
+                        foreign_keys={
+                            "customer_id": customers,
+                            "product_id": products,
+                        },
+                        sequence_by="product_id",
+                    ),
+                }
+            )
+
+        assert len(create_calls) == 1
+        assert create_calls[0]["foreign_key"] == "product_id"
+
+
+# ---------------------------------------------------------------------------
+# 3-table chain (grandparent -> parent -> child)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_api_key")
+class TestThreeTableChain:
+    """Topological execution and integrity over a 3-level FK chain."""
+
+    @pytest.fixture()
+    def districts_df(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {"district_id": [1, 2, 3], "region": ["north", "south", "east"]}
+        )
+
+    @pytest.fixture()
+    def chain_accounts_df(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "account_id": [101, 102, 103, 104],
+                "district_id": [1, 1, 2, 3],
+                "frequency": ["monthly", "weekly", "monthly", "weekly"],
+            }
+        )
+
+    @pytest.fixture()
+    def chain_transactions_df(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "account_id": [101, 101, 102, 103, 104],
+                "amount": [100.0, 200.0, 300.0, 50.0, 75.0],
+                "type": ["credit", "debit", "credit", "credit", "debit"],
+            }
+        )
+
+    def _build_tables(
+        self,
+        districts_df: pd.DataFrame,
+        chain_accounts_df: pd.DataFrame,
+        chain_transactions_df: pd.DataFrame,
+    ) -> tuple[Table, Table, Table]:
+        districts = Table(districts_df, primary_key="district_id")
+        accounts = Table(
+            chain_accounts_df,
+            primary_key="account_id",
+            foreign_keys={"district_id": districts},
+        )
+        transactions = Table(
+            chain_transactions_df, foreign_keys={"account_id": accounts}
+        )
+        return districts, accounts, transactions
+
+    def test_returns_all_three_tables(
+        self,
+        districts_df: pd.DataFrame,
+        chain_accounts_df: pd.DataFrame,
+        chain_transactions_df: pd.DataFrame,
+    ) -> None:
+        dist, acct, tx = self._build_tables(
+            districts_df, chain_accounts_df, chain_transactions_df
+        )
+        with _mock_synthesize_stack():
+            result = dataxid.synthesize_tables(
+                {"districts": dist, "accounts": acct, "transactions": tx}
+            )
+        assert set(result.keys()) == {"districts", "accounts", "transactions"}
+
+    def test_root_uses_synthesize_children_use_create(
+        self,
+        districts_df: pd.DataFrame,
+        chain_accounts_df: pd.DataFrame,
+        chain_transactions_df: pd.DataFrame,
+    ) -> None:
+        """Only the root (no FK) goes through ``synthesize``; the two
+        downstream tables go through ``Model.create``."""
+        dist, acct, tx = self._build_tables(
+            districts_df, chain_accounts_df, chain_transactions_df
+        )
+        synthesize_calls: list[dict[str, Any]] = []
+        create_calls: list[dict[str, Any]] = []
+
+        with _mock_synthesize_stack(
+            synthesize_side_effect=_make_capturing_synthesize(synthesize_calls),
+            create_side_effect=_make_capturing_create(create_calls=create_calls),
+        ):
+            dataxid.synthesize_tables(
+                {"districts": dist, "accounts": acct, "transactions": tx}
+            )
+
+        assert len(synthesize_calls) == 1
+        assert len(create_calls) == 2
+
+    def test_pks_auto_assigned_all_levels(
+        self,
+        districts_df: pd.DataFrame,
+        chain_accounts_df: pd.DataFrame,
+        chain_transactions_df: pd.DataFrame,
+    ) -> None:
+        districts = Table(districts_df, primary_key="district_id", pk_type="int")
+        accounts = Table(
+            chain_accounts_df,
+            primary_key="account_id",
+            pk_type="int",
+            foreign_keys={"district_id": districts},
+        )
+        transactions = Table(
+            chain_transactions_df, foreign_keys={"account_id": accounts}
+        )
+        with _mock_synthesize_stack():
+            result = dataxid.synthesize_tables(
+                {
+                    "districts": districts,
+                    "accounts": accounts,
+                    "transactions": transactions,
+                }
+            )
+        assert list(result["districts"]["district_id"]) == [1, 2, 3]
+        assert result["accounts"]["account_id"].is_unique
+        assert result["accounts"]["account_id"].iloc[0] == 1
+
+    def test_referential_integrity_all_levels(
+        self,
+        districts_df: pd.DataFrame,
+        chain_accounts_df: pd.DataFrame,
+        chain_transactions_df: pd.DataFrame,
+    ) -> None:
+        dist, acct, tx = self._build_tables(
+            districts_df, chain_accounts_df, chain_transactions_df
+        )
+        with _mock_synthesize_stack():
+            result = dataxid.synthesize_tables(
+                {"districts": dist, "accounts": acct, "transactions": tx}
+            )
+        district_ids = set(result["districts"]["district_id"])
+        acct_district_ids = set(result["accounts"]["district_id"])
+        assert acct_district_ids.issubset(district_ids), (
+            f"Orphan district_id in accounts: {acct_district_ids - district_ids}"
+        )
+
+        acct_ids = set(result["accounts"]["account_id"])
+        trans_acct_ids = set(result["transactions"]["account_id"])
+        assert trans_acct_ids.issubset(acct_ids), (
+            f"Orphan account_id in transactions: {trans_acct_ids - acct_ids}"
+        )
+
+    def test_topological_order(
+        self,
+        districts_df: pd.DataFrame,
+        chain_accounts_df: pd.DataFrame,
+        chain_transactions_df: pd.DataFrame,
+    ) -> None:
+        dist, acct, tx = self._build_tables(
+            districts_df, chain_accounts_df, chain_transactions_df
+        )
+        order = _topological_sort(
+            {"transactions": tx, "districts": dist, "accounts": acct}
+        )
+        assert order is not None
+        assert order.index("districts") < order.index("accounts")
+        assert order.index("accounts") < order.index("transactions")
+
+    def test_chain_context_trains_with_real_generates_with_synthetic(
+        self,
+        districts_df: pd.DataFrame,
+        chain_accounts_df: pd.DataFrame,
+        chain_transactions_df: pd.DataFrame,
+    ) -> None:
+        dist, acct, tx = self._build_tables(
+            districts_df, chain_accounts_df, chain_transactions_df
+        )
+        create_calls: list[dict[str, Any]] = []
+
+        with _mock_synthesize_stack(
+            create_side_effect=_make_capturing_create(create_calls=create_calls)
+        ):
+            dataxid.synthesize_tables(
+                {"districts": dist, "accounts": acct, "transactions": tx}
+            )
+
+        assert len(create_calls) == 2
+        tx_call = create_calls[1]
+        parent = tx_call["parent"]
+        parent_key = tx_call.get("parent_key")
+        assert parent_key is not None
+        assert list(parent[parent_key]) == [101, 102, 103, 104]
+
+
+# ---------------------------------------------------------------------------
+# synthesize_tables — distribution forwarding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_api_key")
+class TestSynthesizeTablesDistribution:
+    """``distribution={...}`` is forwarded to the right backend per table."""
+
+    def test_distribution_passed_to_root_table(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        acct = Table(accounts_df, primary_key="account_id")
+        synth_calls: list[dict[str, Any]] = []
+        dist = Distribution(column="district", probabilities={"A": 0.5, "B": 0.5})
+
+        with _mock_synthesize_stack(
+            synthesize_side_effect=_make_capturing_synthesize(synth_calls)
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                },
+                distribution={"accounts": dist},
+            )
+
+        assert len(synth_calls) == 1
+        assert synth_calls[0].get("distribution") is dist
+
+    def test_distribution_passed_to_child_table(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        acct = Table(accounts_df, primary_key="account_id")
+        generate_calls: list[dict[str, Any]] = []
+        dist = Distribution(
+            column="type", probabilities={"credit": 0.5, "debit": 0.5}
+        )
+
+        with _mock_synthesize_stack(
+            create_side_effect=_make_capturing_create(generate_calls=generate_calls)
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                },
+                distribution={"transactions": dist},
+            )
+
+        assert len(generate_calls) == 1
+        assert generate_calls[0].get("distribution") is dist
+
+    def test_distribution_none_by_default(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        acct = Table(accounts_df, primary_key="account_id")
+        synth_calls: list[dict[str, Any]] = []
+        generate_calls: list[dict[str, Any]] = []
+
+        with _mock_synthesize_stack(
+            synthesize_side_effect=_make_capturing_synthesize(synth_calls),
+            create_side_effect=_make_capturing_create(generate_calls=generate_calls),
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                }
+            )
+
+        assert synth_calls[0].get("distribution") is None
+        assert generate_calls[0].get("distribution") is None
+
+    def test_distribution_isolation_per_table(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        """A distribution targeting ``transactions`` must not leak into the
+        ``accounts`` call (and vice versa)."""
+        acct = Table(accounts_df, primary_key="account_id")
+        synth_calls: list[dict[str, Any]] = []
+        generate_calls: list[dict[str, Any]] = []
+        dist = Distribution(
+            column="type", probabilities={"credit": 0.5, "debit": 0.5}
+        )
+
+        with _mock_synthesize_stack(
+            synthesize_side_effect=_make_capturing_synthesize(synth_calls),
+            create_side_effect=_make_capturing_create(generate_calls=generate_calls),
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                },
+                distribution={"transactions": dist},
+            )
+
+        assert synth_calls[0].get("distribution") is None
+        assert generate_calls[0].get("distribution") is dist
+
+
+# ---------------------------------------------------------------------------
+# synthesize_tables — conditions forwarding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_api_key")
+class TestSynthesizeTablesConditions:
+    """``conditions={...}`` is forwarded to the right backend per table."""
+
+    def test_conditions_passed_to_root_table(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        acct = Table(accounts_df, primary_key="account_id")
+        synth_calls: list[dict[str, Any]] = []
+        conds = pd.DataFrame({"district": ["A", "B", "A"]})
+
+        with _mock_synthesize_stack(
+            synthesize_side_effect=_make_capturing_synthesize(synth_calls)
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                },
+                conditions={"accounts": conds},
+            )
+
+        assert len(synth_calls) == 1
+        assert synth_calls[0].get("conditions") is conds
+
+    def test_conditions_passed_to_child_table(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        acct = Table(accounts_df, primary_key="account_id")
+        generate_calls: list[dict[str, Any]] = []
+        conds = pd.DataFrame(
+            {"type": ["credit", "debit", "credit", "debit", "credit"]}
+        )
+
+        with _mock_synthesize_stack(
+            create_side_effect=_make_capturing_create(generate_calls=generate_calls)
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                },
+                conditions={"transactions": conds},
+            )
+
+        assert len(generate_calls) == 1
+        assert generate_calls[0].get("conditions") is conds
+
+    def test_conditions_none_by_default(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        acct = Table(accounts_df, primary_key="account_id")
+        synth_calls: list[dict[str, Any]] = []
+        generate_calls: list[dict[str, Any]] = []
+
+        with _mock_synthesize_stack(
+            synthesize_side_effect=_make_capturing_synthesize(synth_calls),
+            create_side_effect=_make_capturing_create(generate_calls=generate_calls),
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                }
+            )
+
+        assert synth_calls[0].get("conditions") is None
+        assert generate_calls[0].get("conditions") is None
+
+    def test_conditions_isolation_per_table(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        acct = Table(accounts_df, primary_key="account_id")
+        synth_calls: list[dict[str, Any]] = []
+        generate_calls: list[dict[str, Any]] = []
+        conds = pd.DataFrame(
+            {"type": ["credit", "debit", "credit", "debit", "credit"]}
+        )
+
+        with _mock_synthesize_stack(
+            synthesize_side_effect=_make_capturing_synthesize(synth_calls),
+            create_side_effect=_make_capturing_create(generate_calls=generate_calls),
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                },
+                conditions={"transactions": conds},
+            )
+
+        assert synth_calls[0].get("conditions") is None
+        assert generate_calls[0].get("conditions") is conds
+
+    def test_conditions_long_format_forwarded_to_child(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        """Long-format conditions (rows include the FK column) are passed
+        through unchanged so the model can match them against per-parent
+        sequences."""
+        acct = Table(accounts_df, primary_key="account_id")
+        generate_calls: list[dict[str, Any]] = []
+        conds = pd.DataFrame(
+            {
+                "account_id": [101, 101, 102, 103],
+                "type": ["credit", "debit", "credit", "debit"],
+            }
+        )
+
+        with _mock_synthesize_stack(
+            create_side_effect=_make_capturing_create(generate_calls=generate_calls)
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                },
+                conditions={"transactions": conds},
+            )
+
+        assert len(generate_calls) == 1
+        passed_conds = generate_calls[0].get("conditions")
+        assert passed_conds is conds
+        assert "account_id" in passed_conds.columns
+
+
+# ---------------------------------------------------------------------------
+# Internal helper invariants (probed)
+# ---------------------------------------------------------------------------
+
+
+class TestAssignPrimaryKeysDeterminism:
+    """Pin down ``_assign_primary_keys`` invariants the orchestrator relies on."""
+
+    def test_int_pk_is_stateless_across_calls(self) -> None:
+        """Every ``int`` assignment starts at 1 — without this, the orchestrator
+        could not assign monotonic PKs to multiple sibling tables."""
+        df = pd.DataFrame({"x": [10, 20, 30]})
+        first = _assign_primary_keys(df, "pk", pk_type="int")
+        second = _assign_primary_keys(df, "pk", pk_type="int")
+        assert list(first["pk"]) == [1, 2, 3]
+        assert list(second["pk"]) == [1, 2, 3]
+
+    def test_int_pk_resets_per_table_in_orchestrator(
+        self,
+        accounts_df: pd.DataFrame,
+        transactions_df: pd.DataFrame,
+    ) -> None:
+        """Two PK-bearing tables in one ``synthesize_tables`` call each get
+        their own ``[1..n]`` sequence — IDs are not globally monotonic."""
+        # Give transactions its own PK so both tables go through assignment.
+        tx_df = transactions_df.copy()
+        tx_df.insert(0, "tx_id", range(len(tx_df)))
+
+        acct = Table(accounts_df, primary_key="account_id", pk_type="int")
+        tx = Table(
+            tx_df,
+            primary_key="tx_id",
+            pk_type="int",
+            foreign_keys={"account_id": acct},
+        )
+
+        original = dataxid.api_key
+        dataxid.api_key = "dx_test_isolated"
+        try:
+            with _mock_synthesize_stack():
+                result = dataxid.synthesize_tables({"accounts": acct, "transactions": tx})
+        finally:
+            dataxid.api_key = original
+
+        assert list(result["accounts"]["account_id"]) == [1, 2, 3]
+        assert result["transactions"]["tx_id"].iloc[0] == 1
+
+
+class TestRemapForeignKeysDeterminism:
+    """Orphan FKs are reassigned by cycling parent PKs, deterministically."""
+
+    def test_orphans_cycle_through_parent_pks(self) -> None:
+        parent = pd.DataFrame({"pk": [1, 2]})
+        child = pd.DataFrame({"fk": [1, 999, 888, 777, 666]})
+        first = _remap_foreign_keys(child, "fk", parent, "pk")
+        second = _remap_foreign_keys(child, "fk", parent, "pk")
+        assert list(first["fk"]) == list(second["fk"])
+        # First value already valid; orphans cycle [1, 2, 1, 2].
+        assert list(first["fk"]) == [1, 1, 2, 1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Top-level forwarding invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_api_key")
+class TestSynthesizeTablesForwarding:
+    """``seed`` / ``config`` / ``api_key`` reach the per-table backends."""
+
+    def test_seed_forwarded_to_root_synthesize(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        """A user-supplied ``seed`` must reach ``synthesize`` for the root
+        table — otherwise ``synthesize_tables`` could not produce reproducible
+        outputs."""
+        acct = Table(accounts_df, primary_key="account_id")
+        synth_calls: list[dict[str, Any]] = []
+
+        with _mock_synthesize_stack(
+            synthesize_side_effect=_make_capturing_synthesize(synth_calls)
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                },
+                seed=42,
+            )
+
+        assert synth_calls[0].get("seed") == 42
+
+    def test_seed_forwarded_to_child_generate(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        """The same ``seed`` must reach the child's ``model.generate`` call."""
+        acct = Table(accounts_df, primary_key="account_id")
+        generate_calls: list[dict[str, Any]] = []
+
+        with _mock_synthesize_stack(
+            create_side_effect=_make_capturing_create(generate_calls=generate_calls)
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                },
+                seed=42,
+            )
+
+        assert generate_calls[0].get("seed") == 42
+
+    def test_config_forwarded_to_create_and_synthesize(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        """A ``ModelConfig`` instance reaches both backends so per-table
+        training stays consistent with the user's intent."""
+        cfg = ModelConfig(max_epochs=5)
+        acct = Table(accounts_df, primary_key="account_id")
+        synth_calls: list[dict[str, Any]] = []
+        create_calls: list[dict[str, Any]] = []
+
+        with _mock_synthesize_stack(
+            synthesize_side_effect=_make_capturing_synthesize(synth_calls),
+            create_side_effect=_make_capturing_create(create_calls=create_calls),
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                },
+                config=cfg,
+            )
+
+        assert synth_calls[0].get("config") is cfg
+        assert create_calls[0].get("config") is cfg
+
+    def test_api_key_override_forwarded(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        """An explicit ``api_key=`` overrides ``dataxid.api_key`` for every
+        downstream call."""
+        acct = Table(accounts_df, primary_key="account_id")
+        synth_calls: list[dict[str, Any]] = []
+        create_calls: list[dict[str, Any]] = []
+
+        with _mock_synthesize_stack(
+            synthesize_side_effect=_make_capturing_synthesize(synth_calls),
+            create_side_effect=_make_capturing_create(create_calls=create_calls),
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                },
+                api_key="sk_explicit_override",
+            )
+
+        assert synth_calls[0].get("api_key") == "sk_explicit_override"
+        assert create_calls[0].get("api_key") == "sk_explicit_override"
+
+
+# ---------------------------------------------------------------------------
+# Resource cleanup invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_api_key")
+class TestModelCleanup:
+    """Child models are deleted after each child table is generated."""
+
+    def test_child_model_deleted_on_success(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        """``Model.delete()`` runs after a successful ``generate`` so the
+        server-side model is not orphaned."""
+        acct = Table(accounts_df, primary_key="account_id")
+        created_models: list[MagicMock] = []
+
+        def _track_create(*args: Any, **kwargs: Any) -> MagicMock:
+            m = _mock_model_create(*args, **kwargs)
+            created_models.append(m)
+            return m
+
+        with _mock_synthesize_stack(create_side_effect=_track_create):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                }
+            )
+
+        assert len(created_models) == 1
+        created_models[0].delete.assert_called_once()
+
+    def test_child_model_deleted_on_generate_failure(
+        self, accounts_df: pd.DataFrame, transactions_df: pd.DataFrame
+    ) -> None:
+        """If ``generate`` raises, the model is still deleted before the
+        exception propagates — no leaks on the failure path."""
+        acct = Table(accounts_df, primary_key="account_id")
+        created_models: list[MagicMock] = []
+
+        def _track_create(*args: Any, **kwargs: Any) -> MagicMock:
+            m = _mock_model_create(*args, **kwargs)
+
+            def _boom(**_: Any) -> None:
+                raise RuntimeError("simulated generate failure")
+
+            m.generate = _boom
+            created_models.append(m)
+            return m
+
+        with (
+            _mock_synthesize_stack(create_side_effect=_track_create),
+            pytest.raises(RuntimeError, match="simulated generate failure"),
+        ):
+            dataxid.synthesize_tables(
+                {
+                    "accounts": acct,
+                    "transactions": Table(
+                        transactions_df, foreign_keys={"account_id": acct}
+                    ),
+                }
+            )
+
+        assert len(created_models) == 1
+        created_models[0].delete.assert_called_once()

--- a/tests/sdk/test_validation_boundary.py
+++ b/tests/sdk/test_validation_boundary.py
@@ -271,6 +271,55 @@ class TestModelCreateBoundary:
             )
         assert exc_info.value.param == "parent_encoding_types"
 
+    def test_parent_encoding_types_unknown_value_rejected(
+        self,
+        sample_df: pd.DataFrame,
+        parent_df: pd.DataFrame,
+        no_side_effects: tuple,
+    ) -> None:
+        """Bad value should fail at the boundary, not deep inside ``analyze()``."""
+        with pytest.raises(InvalidRequestError, match="must be one of") as exc_info:
+            Model.create(
+                data=sample_df,
+                parent=parent_df,
+                parent_encoding_types={"region": "FANCY_TYPE"},
+            )
+        assert exc_info.value.param == "parent_encoding_types"
+
+    def test_parent_encoding_types_non_string_key_rejected(
+        self,
+        sample_df: pd.DataFrame,
+        parent_df: pd.DataFrame,
+        no_side_effects: tuple,
+    ) -> None:
+        with pytest.raises(
+            InvalidRequestError, match="keys must be strings"
+        ) as exc_info:
+            Model.create(
+                data=sample_df,
+                parent=parent_df,
+                parent_encoding_types={1: "AUTO"},  # type: ignore[dict-item]
+            )
+        assert exc_info.value.param == "parent_encoding_types"
+
+    def test_parent_encoding_types_context_error_takes_priority(
+        self,
+        sample_df: pd.DataFrame,
+        no_side_effects: tuple,
+    ) -> None:
+        """When ``parent`` is missing, the context error wins over content errors.
+
+        Even with an invalid value, the user's real problem is the missing
+        ``parent`` argument; surfacing the content failure first would send
+        them down a debug detour.
+        """
+        with pytest.raises(InvalidRequestError, match="without parent") as exc_info:
+            Model.create(
+                data=sample_df,
+                parent_encoding_types={"col": "FANCY_TYPE"},
+            )
+        assert exc_info.value.param == "parent_encoding_types"
+
     def test_foreign_key_non_string_rejected(
         self, sample_df: pd.DataFrame, no_side_effects: tuple
     ) -> None:

--- a/tests/sdk/test_validation_boundary.py
+++ b/tests/sdk/test_validation_boundary.py
@@ -1,0 +1,504 @@
+# Copyright (c) 2026 DataXID Teknoloji ve Ticaret A.Ş.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Boundary validation tests for the public SDK surface.
+
+Public entry points (``synthesize``, ``synthesize_tables``, ``Model.create``,
+``Model.generate``, ``Model.impute``, ``Table.__post_init__``,
+``DataxidClient.__init__``) reject malformed inputs *before* any side effect
+runs — local analysis, HTTP calls, or training. Each test asserts:
+
+* the failure surfaces as :class:`InvalidRequestError`,
+* the ``param`` attribute names the offending field, and
+* no HTTP request and no training pass were started.
+"""
+
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import httpx
+import pandas as pd
+import pytest
+
+import dataxid
+from dataxid import Synthetic, Table
+from dataxid.client._http import DataxidClient
+from dataxid.exceptions import InvalidRequestError
+from dataxid.training._model import Model
+
+
+@pytest.fixture(autouse=True)
+def _set_api_key() -> Iterator[None]:
+    original = dataxid.api_key
+    dataxid.api_key = "dx_test_boundary"
+    yield
+    dataxid.api_key = original
+
+
+@pytest.fixture
+def sample_df() -> pd.DataFrame:
+    return pd.DataFrame({
+        "age": [25, 30, 35, 40],
+        "city": ["A", "B", "A", "C"],
+    })
+
+
+@pytest.fixture
+def parent_df() -> pd.DataFrame:
+    return pd.DataFrame({
+        "id": [1, 2, 3, 4],
+        "region": ["N", "S", "E", "W"],
+    })
+
+
+@pytest.fixture
+def no_side_effects() -> Iterator[tuple]:
+    """Patch HTTP transport and training loop; assert neither was invoked.
+
+    Boundary validation must reject bad inputs before any of these run, so
+    a positive ``call_count`` is itself a regression.
+    """
+    with patch.object(DataxidClient, "_request") as mock_req, \
+         patch("dataxid.training._model.train_frozen") as mock_train:
+        yield mock_req, mock_train
+        assert mock_req.call_count == 0, (
+            "HTTP request was made before validation rejected the input"
+        )
+        assert mock_train.call_count == 0, (
+            "Training started before validation rejected the input"
+        )
+
+
+# ---------------------------------------------------------------------------
+# synthesize()
+# ---------------------------------------------------------------------------
+
+class TestSynthesizeBoundary:
+    """``synthesize()`` rejects malformed scalar tunables up-front."""
+
+    def test_seed_non_int_rejected(self, sample_df: pd.DataFrame) -> None:
+        with pytest.raises(InvalidRequestError, match="seed") as exc_info:
+            dataxid.synthesize(data=sample_df, seed="42")  # type: ignore[arg-type]
+        assert exc_info.value.param == "seed"
+
+    def test_seed_bool_rejected(self, sample_df: pd.DataFrame) -> None:
+        """``True`` is an ``int`` subclass; reject it explicitly so callers
+        cannot accidentally seed the RNG with a boolean."""
+        with pytest.raises(InvalidRequestError, match="seed") as exc_info:
+            dataxid.synthesize(data=sample_df, seed=True)  # type: ignore[arg-type]
+        assert exc_info.value.param == "seed"
+
+    def test_diversity_zero_rejected(self, sample_df: pd.DataFrame) -> None:
+        with pytest.raises(InvalidRequestError, match="diversity") as exc_info:
+            dataxid.synthesize(data=sample_df, diversity=0)
+        assert exc_info.value.param == "diversity"
+
+    def test_diversity_negative_rejected(self, sample_df: pd.DataFrame) -> None:
+        with pytest.raises(InvalidRequestError, match="diversity") as exc_info:
+            dataxid.synthesize(data=sample_df, diversity=-0.5)
+        assert exc_info.value.param == "diversity"
+
+    def test_rare_cutoff_above_one_rejected(self, sample_df: pd.DataFrame) -> None:
+        with pytest.raises(InvalidRequestError, match="rare_cutoff") as exc_info:
+            dataxid.synthesize(data=sample_df, rare_cutoff=1.5)
+        assert exc_info.value.param == "rare_cutoff"
+
+    def test_rare_cutoff_zero_rejected(self, sample_df: pd.DataFrame) -> None:
+        with pytest.raises(InvalidRequestError, match="rare_cutoff") as exc_info:
+            dataxid.synthesize(data=sample_df, rare_cutoff=0)
+        assert exc_info.value.param == "rare_cutoff"
+
+    def test_rare_strategy_unknown_rejected(self, sample_df: pd.DataFrame) -> None:
+        with pytest.raises(InvalidRequestError, match="rare_strategy") as exc_info:
+            dataxid.synthesize(
+                data=sample_df, rare_strategy="masc",  # type: ignore[arg-type]
+            )
+        assert exc_info.value.param == "rare_strategy"
+
+
+# ---------------------------------------------------------------------------
+# synthesize_tables()
+# ---------------------------------------------------------------------------
+
+class TestSynthesizeTablesBoundary:
+    """``synthesize_tables()`` rejects mis-shaped ``tables`` and per-table dicts."""
+
+    def test_tables_not_a_dict_rejected(self, sample_df: pd.DataFrame) -> None:
+        with pytest.raises(InvalidRequestError, match="tables") as exc_info:
+            dataxid.synthesize_tables(tables=[Table(sample_df)])  # type: ignore[arg-type]
+        assert exc_info.value.param == "tables"
+
+    def test_tables_value_not_a_table_rejected(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        with pytest.raises(
+            InvalidRequestError, match=r"tables\['users'\] must be a Table"
+        ) as exc_info:
+            dataxid.synthesize_tables(
+                tables={"users": sample_df},  # type: ignore[dict-item]
+            )
+        assert exc_info.value.param == "tables"
+
+    def test_tables_empty_rejected(self) -> None:
+        with pytest.raises(InvalidRequestError, match="at least one table") as exc_info:
+            dataxid.synthesize_tables(tables={})
+        assert exc_info.value.param == "tables"
+
+    def test_seed_non_int_rejected(self, sample_df: pd.DataFrame) -> None:
+        with pytest.raises(InvalidRequestError, match="seed") as exc_info:
+            dataxid.synthesize_tables(
+                tables={"t": Table(sample_df)}, seed="42",  # type: ignore[arg-type]
+            )
+        assert exc_info.value.param == "seed"
+
+    def test_synthetic_unknown_table_rejected(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        with pytest.raises(
+            InvalidRequestError, match="synthetic refers to unknown table"
+        ) as exc_info:
+            dataxid.synthesize_tables(
+                tables={"users": Table(sample_df)},
+                synthetic={"accountss": Synthetic(diversity=0.9)},
+            )
+        assert exc_info.value.param == "synthetic"
+
+    def test_synthetic_value_wrong_type_rejected(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        with pytest.raises(
+            InvalidRequestError, match="must be a Synthetic instance"
+        ) as exc_info:
+            dataxid.synthesize_tables(
+                tables={"users": Table(sample_df)},
+                synthetic={"users": {"diversity": 0.9}},  # type: ignore[dict-item]
+            )
+        assert exc_info.value.param == "synthetic"
+
+    def test_distribution_value_wrong_type_rejected(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        with pytest.raises(
+            InvalidRequestError, match="must be a Distribution instance"
+        ) as exc_info:
+            dataxid.synthesize_tables(
+                tables={"users": Table(sample_df)},
+                distribution={"users": {"column": "city"}},  # type: ignore[dict-item]
+            )
+        assert exc_info.value.param == "distribution"
+
+    def test_bias_value_wrong_type_rejected(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        with pytest.raises(
+            InvalidRequestError, match="must be a Bias instance"
+        ) as exc_info:
+            dataxid.synthesize_tables(
+                tables={"users": Table(sample_df)},
+                bias={"users": {"target": "city"}},  # type: ignore[dict-item]
+            )
+        assert exc_info.value.param == "bias"
+
+    def test_conditions_value_wrong_type_rejected(
+        self, sample_df: pd.DataFrame
+    ) -> None:
+        with pytest.raises(
+            InvalidRequestError, match="must be a pandas DataFrame"
+        ) as exc_info:
+            dataxid.synthesize_tables(
+                tables={"users": Table(sample_df)},
+                conditions={"users": [{"city": "A"}]},  # type: ignore[dict-item]
+            )
+        assert exc_info.value.param == "conditions"
+
+
+# ---------------------------------------------------------------------------
+# Model.create()
+# ---------------------------------------------------------------------------
+
+class TestModelCreateBoundary:
+    """``Model.create()`` rejects bad inputs before any side effect runs."""
+
+    def test_data_not_dataframe_rejected(
+        self, no_side_effects: tuple
+    ) -> None:
+        with pytest.raises(InvalidRequestError, match="data") as exc_info:
+            Model.create(data=[{"age": 25}])  # type: ignore[arg-type]
+        assert exc_info.value.param == "data"
+
+    def test_data_none_rejected(self, no_side_effects: tuple) -> None:
+        with pytest.raises(InvalidRequestError, match="data") as exc_info:
+            Model.create(data=None)  # type: ignore[arg-type]
+        assert exc_info.value.param == "data"
+
+    def test_n_samples_zero_rejected(
+        self, sample_df: pd.DataFrame, no_side_effects: tuple
+    ) -> None:
+        with pytest.raises(InvalidRequestError, match="n_samples") as exc_info:
+            Model.create(data=sample_df, n_samples=0)
+        assert exc_info.value.param == "n_samples"
+
+    def test_n_samples_negative_rejected(
+        self, sample_df: pd.DataFrame, no_side_effects: tuple
+    ) -> None:
+        with pytest.raises(InvalidRequestError, match="n_samples") as exc_info:
+            Model.create(data=sample_df, n_samples=-5)
+        assert exc_info.value.param == "n_samples"
+
+    def test_n_samples_bool_rejected(
+        self, sample_df: pd.DataFrame, no_side_effects: tuple
+    ) -> None:
+        with pytest.raises(InvalidRequestError, match="n_samples") as exc_info:
+            Model.create(data=sample_df, n_samples=True)  # type: ignore[arg-type]
+        assert exc_info.value.param == "n_samples"
+
+    def test_parent_not_dataframe_rejected(
+        self, sample_df: pd.DataFrame, no_side_effects: tuple
+    ) -> None:
+        with pytest.raises(InvalidRequestError, match="parent") as exc_info:
+            Model.create(data=sample_df, parent="not a df")  # type: ignore[arg-type]
+        assert exc_info.value.param == "parent"
+
+    def test_parent_encoding_types_not_dict_rejected(
+        self, sample_df: pd.DataFrame, no_side_effects: tuple
+    ) -> None:
+        with pytest.raises(
+            InvalidRequestError, match="parent_encoding_types"
+        ) as exc_info:
+            Model.create(
+                data=sample_df,
+                parent_encoding_types=["region"],  # type: ignore[arg-type]
+            )
+        assert exc_info.value.param == "parent_encoding_types"
+
+    def test_foreign_key_non_string_rejected(
+        self, sample_df: pd.DataFrame, no_side_effects: tuple
+    ) -> None:
+        with pytest.raises(InvalidRequestError, match="foreign_key") as exc_info:
+            Model.create(data=sample_df, foreign_key=42)  # type: ignore[arg-type]
+        assert exc_info.value.param == "foreign_key"
+
+    def test_parent_key_non_string_rejected(
+        self, sample_df: pd.DataFrame, no_side_effects: tuple
+    ) -> None:
+        with pytest.raises(InvalidRequestError, match="parent_key") as exc_info:
+            Model.create(data=sample_df, parent_key=42)  # type: ignore[arg-type]
+        assert exc_info.value.param == "parent_key"
+
+
+# ---------------------------------------------------------------------------
+# Model.generate() / Model.impute()
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def trained_model(
+    sample_df: pd.DataFrame,
+) -> Iterator[Model]:
+    """Build a Model without exercising real network or training.
+
+    Stubs ``DataxidClient._request`` and ``train_frozen`` for the duration
+    of construction, so the resulting Model is suitable for boundary tests
+    that should reject inputs before any further I/O.
+    """
+    def _fake_train(model: Model, **_kwargs: object) -> None:
+        model.status = "ready"
+
+    create_resp = {
+        "data": {"id": "mdl_test", "status": "training", "config": {}},
+    }
+    with patch.object(
+        DataxidClient, "_request", return_value=create_resp,
+    ), patch("dataxid.training._model.train_frozen", _fake_train):
+        model = Model.create(
+            data=sample_df,
+            config={"embedding_dim": 16, "model_size": "small", "max_epochs": 1},
+        )
+        yield model
+
+
+class TestModelGenerateBoundary:
+    """``Model.generate()`` rejects malformed kwargs before sending a request."""
+
+    def test_n_samples_zero_rejected(self, trained_model: Model) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req:
+            with pytest.raises(InvalidRequestError, match="n_samples") as exc_info:
+                trained_model.generate(n_samples=0)
+            assert mock_req.call_count == 0
+        assert exc_info.value.param == "n_samples"
+
+    def test_n_samples_negative_rejected(self, trained_model: Model) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req:
+            with pytest.raises(InvalidRequestError, match="n_samples") as exc_info:
+                trained_model.generate(n_samples=-1)
+            assert mock_req.call_count == 0
+        assert exc_info.value.param == "n_samples"
+
+    def test_conditions_non_dataframe_rejected(self, trained_model: Model) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req:
+            with pytest.raises(InvalidRequestError, match="conditions") as exc_info:
+                trained_model.generate(
+                    conditions={"city": ["A"]},  # type: ignore[arg-type]
+                )
+            assert mock_req.call_count == 0
+        assert exc_info.value.param == "conditions"
+
+    def test_parent_non_dataframe_rejected(self, trained_model: Model) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req:
+            with pytest.raises(InvalidRequestError, match="parent") as exc_info:
+                trained_model.generate(parent="oops")  # type: ignore[arg-type]
+            assert mock_req.call_count == 0
+        assert exc_info.value.param == "parent"
+
+
+class TestModelImputeBoundary:
+    """``Model.impute()`` rejects malformed kwargs before sending a request."""
+
+    def test_X_non_dataframe_rejected(self, trained_model: Model) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req:
+            with pytest.raises(InvalidRequestError, match="X must be") as exc_info:
+                trained_model.impute(X={"a": [1]})  # type: ignore[arg-type]
+            assert mock_req.call_count == 0
+        assert exc_info.value.param == "X"
+
+    def test_parent_non_dataframe_rejected(
+        self, trained_model: Model, sample_df: pd.DataFrame
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req:
+            with pytest.raises(InvalidRequestError, match="parent") as exc_info:
+                trained_model.impute(X=sample_df, parent="oops")  # type: ignore[arg-type]
+            assert mock_req.call_count == 0
+        assert exc_info.value.param == "parent"
+
+    def test_trials_zero_rejected(
+        self, trained_model: Model, sample_df: pd.DataFrame
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req:
+            with pytest.raises(InvalidRequestError, match="trials") as exc_info:
+                trained_model.impute(X=sample_df, trials=0)
+            assert mock_req.call_count == 0
+        assert exc_info.value.param == "trials"
+
+    def test_trials_negative_rejected(
+        self, trained_model: Model, sample_df: pd.DataFrame
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req:
+            with pytest.raises(InvalidRequestError, match="trials") as exc_info:
+                trained_model.impute(X=sample_df, trials=-1)
+            assert mock_req.call_count == 0
+        assert exc_info.value.param == "trials"
+
+    def test_trials_non_int_rejected(
+        self, trained_model: Model, sample_df: pd.DataFrame
+    ) -> None:
+        with patch.object(DataxidClient, "_request") as mock_req:
+            with pytest.raises(InvalidRequestError, match="trials") as exc_info:
+                trained_model.impute(X=sample_df, trials=1.5)  # type: ignore[arg-type]
+            assert mock_req.call_count == 0
+        assert exc_info.value.param == "trials"
+
+
+# ---------------------------------------------------------------------------
+# Table — extra invariants beyond the existing test_synthesize_tables coverage
+# ---------------------------------------------------------------------------
+
+class TestTableExtraValidation:
+    """``Table.__post_init__`` rejects nonsensical FK topologies."""
+
+    def test_fk_equal_to_primary_key_rejected(self) -> None:
+        df = pd.DataFrame({"id": [1, 2], "region": ["N", "S"]})
+        parent = Table(
+            pd.DataFrame({"id": [1, 2]}),
+            primary_key="id",
+        )
+        with pytest.raises(
+            InvalidRequestError, match="cannot also be the primary_key"
+        ) as exc_info:
+            Table(df, primary_key="id", foreign_keys={"id": parent})
+        assert exc_info.value.param == "foreign_keys"
+
+    def test_self_reference_rejected(self) -> None:
+        """A Table whose foreign_keys point back at itself would silently
+        create a cycle. ``__post_init__`` rejects it explicitly so callers
+        see a targeted error instead of a topological-sort cycle message."""
+        df = pd.DataFrame({"id": [1, 2], "parent_id": [1, 1]})
+        tbl = Table(df, primary_key="id")
+        tbl.foreign_keys = {"parent_id": tbl}
+        with pytest.raises(
+            InvalidRequestError, match="self-references are not supported"
+        ) as exc_info:
+            tbl.__post_init__()
+        assert exc_info.value.param == "foreign_keys"
+
+
+# ---------------------------------------------------------------------------
+# DataxidClient
+# ---------------------------------------------------------------------------
+
+class TestDataxidClientBoundary:
+    """``DataxidClient.__init__`` enforces the secure defaults of the SDK."""
+
+    def test_api_key_non_string_rejected(self) -> None:
+        with pytest.raises(InvalidRequestError, match="api_key") as exc_info:
+            DataxidClient(api_key=42)  # type: ignore[arg-type]
+        assert exc_info.value.param == "api_key"
+
+    def test_base_url_non_string_rejected(self) -> None:
+        with pytest.raises(InvalidRequestError, match="base_url") as exc_info:
+            DataxidClient(base_url=42)  # type: ignore[arg-type]
+        assert exc_info.value.param == "base_url"
+
+    def test_base_url_empty_rejected(self) -> None:
+        with pytest.raises(InvalidRequestError, match="non-empty") as exc_info:
+            DataxidClient(base_url="   ")
+        assert exc_info.value.param == "base_url"
+
+    def test_base_url_https_accepted(self) -> None:
+        DataxidClient(base_url="https://api.dataxid.com")
+
+    def test_base_url_http_localhost_accepted(self) -> None:
+        DataxidClient(base_url="http://localhost:8000")
+
+    def test_base_url_http_127_0_0_1_accepted(self) -> None:
+        DataxidClient(base_url="http://127.0.0.1:8000/v1")
+
+    def test_base_url_http_non_localhost_rejected(self) -> None:
+        with pytest.raises(InvalidRequestError, match="plaintext") as exc_info:
+            DataxidClient(base_url="http://api.dataxid.com")
+        assert exc_info.value.param == "base_url"
+
+    def test_base_url_no_scheme_rejected(self) -> None:
+        with pytest.raises(InvalidRequestError, match="must start with") as exc_info:
+            DataxidClient(base_url="api.dataxid.com")
+        assert exc_info.value.param == "base_url"
+
+    def test_base_url_unknown_scheme_rejected(self) -> None:
+        with pytest.raises(InvalidRequestError, match="scheme must be") as exc_info:
+            DataxidClient(base_url="ftp://api.dataxid.com")
+        assert exc_info.value.param == "base_url"
+
+    def test_timeout_wrong_type_rejected(self) -> None:
+        with pytest.raises(InvalidRequestError, match="timeout") as exc_info:
+            DataxidClient(timeout="30")  # type: ignore[arg-type]
+        assert exc_info.value.param == "timeout"
+
+    def test_timeout_bool_rejected(self) -> None:
+        with pytest.raises(InvalidRequestError, match="timeout") as exc_info:
+            DataxidClient(timeout=True)  # type: ignore[arg-type]
+        assert exc_info.value.param == "timeout"
+
+    def test_timeout_httpx_object_accepted(self) -> None:
+        DataxidClient(timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0))
+
+    def test_global_base_url_revalidated_on_property_access(self) -> None:
+        """Setting ``dataxid.base_url`` to an insecure value must surface as
+        an error when the client is actually used, not silently leak the API
+        key over plaintext HTTP."""
+        original = dataxid.base_url
+        try:
+            dataxid.base_url = "http://api.dataxid.com"
+            client = DataxidClient()
+            with pytest.raises(InvalidRequestError, match="plaintext") as exc_info:
+                _ = client.base_url
+            assert exc_info.value.param == "base_url"
+        finally:
+            dataxid.base_url = original

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ wheels = [
 
 [[package]]
 name = "dataxid"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What

Validation hardening across the public API — every input is validated at the boundary and every validation failure raises a single typed exception (`InvalidRequestError`). Version bumped to 0.3.1.

## Why

v0.3.0 delivered the generation-time control surface, but validation was inconsistent across the public API. Some methods deferred input checks to the encoder, HTTP client, or training loop, surfacing errors only after expensive side effects had already begun. Failures used a mix of `ValueError` and `TypeError` without naming the offending parameter, forcing callers to handle multiple exception types and guess which argument was wrong. This release tightens the contract so the SDK fails fast, with a single typed exception, and a populated `param` field.

## How

`InvalidRequestError` is now the single validation exception; it multi-inherits from `DataxidError` and `ValueError` so `except ValueError` keeps working

`synthesize`, `synthesize_tables`, `Model.create`, `Model.generate`, `Model.impute`, `Table.__post_init__`, and `DataxidClient.__init__` validate inputs at the public boundary before any side effect runs

`ModelConfig.model_size` and `encoding_types` are now rejected for unknown values at construction time, instead of crashing inside the encoder

`Table` rejects foreign keys that match the table's own primary key and self-referencing tables; `synthesize_tables` rejects malformed `tables` dicts

`DataxidClient.base_url` requires HTTPS for non-loopback hosts

New read-only properties: `Encoder.protect_rare_enabled`, `Model.is_sequential`, `Model.has_context`

Breaking: callers catching `TypeError` for config errors must change to `except InvalidRequestError` (or `except ValueError`); callers overriding `DataxidClient.base_url` must use HTTPS — see CHANGELOG for migration

## Test Plan

* Existing tests pass (666 passed, 1 skipped via `uv run pytest tests/sdk`)
* New `tests/sdk/test_validation_boundary.py` covers every public-API boundary
* Verified on Python 3.10, 3.11, 3.12