### PR TITLE
fix(synthesize): validate data is a non-None pandas DataFrame up-front (#151)

### DIFF
--- a/dataxid/__init__.py
+++ b/dataxid/__init__.py
@@ -152,6 +152,16 @@ def synthesize(
         InvalidRequestError: If any user input fails validation.
             Inherits from :class:`ValueError`.
     """
+    if data is None:
+        raise InvalidRequestError(
+            "data cannot be None. Please provide a pandas DataFrame.",
+            param="data",
+        )
+    if not isinstance(data, pd.DataFrame):
+        raise InvalidRequestError(
+            f"data must be a pandas DataFrame, got {type(data).__name__}.",
+            param="data",
+        )
     if seed is not _UNSET and seed is not None and (
         not isinstance(seed, int) or isinstance(seed, bool)
     ):

--- a/tests/sdk/test_model.py
+++ b/tests/sdk/test_model.py
@@ -551,6 +551,21 @@ class TestSynthesize:
         assert len(delete_calls) == 1
 
 
+class TestSynthesizeInputValidation:
+    """``synthesize()`` must reject bad ``data`` up-front with a clear error
+    (#151). Previously passing ``None`` produced a deep ``AttributeError``
+    when something downstream accessed ``data.columns``."""
+
+    def test_data_none_raises_invalid_request_error(self) -> None:
+        with pytest.raises(InvalidRequestError, match="data cannot be None"):
+            dataxid.synthesize(data=None, n_samples=10)
+
+    def test_data_non_dataframe_raises_invalid_request_error(self) -> None:
+        for bad in ([{"a": 1}], "not a frame", 42, {"a": [1, 2]}):
+            with pytest.raises(InvalidRequestError, match="must be a pandas DataFrame"):
+                dataxid.synthesize(data=bad, n_samples=10)
+
+
 class TestStatusTransitions:
     """The full create → generate → delete lifecycle keeps status coherent."""
 

--- a/tests/sdk/test_model.py
+++ b/tests/sdk/test_model.py
@@ -552,10 +552,6 @@ class TestSynthesize:
 
 
 class TestSynthesizeInputValidation:
-    """``synthesize()`` must reject bad ``data`` up-front with a clear error
-    (#151). Previously passing ``None`` produced a deep ``AttributeError``
-    when something downstream accessed ``data.columns``."""
-
     def test_data_none_raises_invalid_request_error(self) -> None:
         with pytest.raises(InvalidRequestError, match="data cannot be None"):
             dataxid.synthesize(data=None, n_samples=10)

--- a/tests/sdk/test_validation_boundary.py
+++ b/tests/sdk/test_validation_boundary.py
@@ -53,11 +53,7 @@ def parent_df() -> pd.DataFrame:
 
 @pytest.fixture
 def no_side_effects() -> Iterator[tuple]:
-    """Patch HTTP transport and training loop; assert neither was invoked.
-
-    Boundary validation must reject bad inputs before any of these run, so
-    a positive ``call_count`` is itself a regression.
-    """
+    """Patch HTTP transport and training loop; assert neither was invoked."""
     with patch.object(DataxidClient, "_request") as mock_req, \
          patch("dataxid.training._model.train_frozen") as mock_train:
         yield mock_req, mock_train


### PR DESCRIPTION
## What

Validate `data` is a non-`None` pandas `DataFrame` at the top of `synthesize()` so callers get a clear `InvalidRequestError` instead of a downstream `AttributeError`.

## Why

Closes #151 (and #64). `synthesize()` previously deferred input validation until something downstream tried to access `data.columns`, surfacing a generic `AttributeError: 'NoneType' object has no attribute 'columns'` (or similar for non-DataFrame inputs).

## How

Adds an up-front check that raises the project's existing `InvalidRequestError` with a clear, parameter-tagged message:

```
InvalidRequestError: data cannot be None. Please provide a pandas DataFrame.
InvalidRequestError: data must be a pandas DataFrame, got dict.
```

`InvalidRequestError` is already a `ValueError` subclass, so existing callers that catch `ValueError` keep working, they just get a useful message now instead of an `AttributeError` stack trace.

## Test Plan

- [x] Existing tests pass (`pytest tests/`)
- [x] New tests added (if applicable)
- [x] Tested manually with a sample dataset

Regression test `TestSynthesizeInputValidation` in `tests/sdk/test_model.py` covers the `None` case (the bug repro) and a handful of non-DataFrame types.
