### PR TITLE
fix(synthesize): validate data has no duplicate column names (#47)

### DIFF
--- a/dataxid/training/_model.py
+++ b/dataxid/training/_model.py
@@ -328,6 +328,14 @@ class Model:
                 f"data must be a pandas DataFrame, got {type(data).__name__}",
                 param="data",
             )
+        dup_mask = data.columns.duplicated()
+        if dup_mask.any():
+            duplicates = sorted(set(data.columns[dup_mask].tolist()))
+            raise InvalidRequestError(
+                f"data contains duplicate column names: {duplicates}. "
+                "Please rename columns to be unique.",
+                param="data",
+            )
         if n_samples is not None and (
             not isinstance(n_samples, int)
             or isinstance(n_samples, bool)

--- a/tests/sdk/test_validation_boundary.py
+++ b/tests/sdk/test_validation_boundary.py
@@ -231,6 +231,18 @@ class TestModelCreateBoundary:
             Model.create(data=None)  # type: ignore[arg-type]
         assert exc_info.value.param == "data"
 
+    def test_data_duplicate_columns_rejected(
+        self, no_side_effects: tuple
+    ) -> None:
+        df = pd.DataFrame(
+            [[1, 2, 3], [4, 5, 6]], columns=["a", "b", "a"]
+        )
+        with pytest.raises(
+            InvalidRequestError, match="duplicate column names"
+        ) as exc_info:
+            Model.create(data=df)
+        assert exc_info.value.param == "data"
+
     def test_n_samples_zero_rejected(
         self, sample_df: pd.DataFrame, no_side_effects: tuple
     ) -> None:


### PR DESCRIPTION
Closes #47.

`Model.create` now raises `InvalidRequestError` when `data` contains duplicate column names, instead of falling through to a confusing `AttributeError: 'DataFrame' object has no attribute 'dtype'` later in encoding.

Before:
```
AttributeError: 'DataFrame' object has no attribute 'dtype'
```

After:
```
InvalidRequestError: data contains duplicate column names: ['a']. Please rename columns to be unique.
```

Test: `tests/sdk/test_validation_boundary.py::TestModelCreateBoundary::test_data_duplicate_columns_rejected` (full validation_boundary suite: 53/53 passing).