### PR TITLE
fix(pipeline): align root_keys index with df to handle non-zero-based indices (#104)

### DIFF
--- a/dataxid/pipeline/_analyze.py
+++ b/dataxid/pipeline/_analyze.py
@@ -505,7 +505,13 @@ def compute_stats(
     """Analyze raw features and produce column_stats for encoding."""
     encoding_types = encoding_types or {}
     column_stats: dict[str, dict] = {}
-    root_keys = pd.Series(range(len(df)), name="__root_key__")
+    # root_keys must share its index with ``df`` so the pd.concat alignment in
+    # the per-type _analyze_* helpers preserves every row. Using
+    # ``pd.Series(range(len(df)))`` previously yielded a default 0..N-1 index
+    # which silently produced an all-NaN merge whenever ``df`` had a
+    # non-zero-based index (e.g. df.tail(), df.iloc[]), surfacing later as
+    # ZeroDivisionError deep in _reduce_numeric.
+    root_keys = pd.Series(range(len(df)), index=df.index, name="__root_key__")
 
     for feature in features:
         if feature not in df.columns:

--- a/tests/sdk/test_encoder.py
+++ b/tests/sdk/test_encoder.py
@@ -105,6 +105,21 @@ class TestAnalyze:
         assert first["column_stats"] == second["column_stats"]
         assert first["empirical_probs"] == second["empirical_probs"]
 
+    def test_non_zero_based_index_does_not_crash(
+        self, encoder: Encoder, sample_df: pd.DataFrame
+    ) -> None:
+        """Regression: a DataFrame with a non-zero-based index (df.tail(),
+        df.iloc[], or an explicit RangeIndex starting > 0) previously caused
+        a ZeroDivisionError deep in _reduce_numeric because root_keys used a
+        0-based index that did not align with the DataFrame's index.
+        """
+        shifted = sample_df.copy()
+        shifted.index = pd.RangeIndex(start=1000, stop=1000 + len(shifted))
+        meta = encoder.analyze(shifted)
+        baseline = encoder.analyze(sample_df.reset_index(drop=True))
+        assert meta["features"] == baseline["features"]
+        assert meta["cardinalities"] == baseline["cardinalities"]
+
 
 class TestPrepare:
     """``Encoder.prepare()`` — pre-encode data into tensors."""


### PR DESCRIPTION
Closes #104.

`compute_stats()` built `root_keys = pd.Series(range(len(df)), name="__root_key__")`, which gives the Series a default 0..N-1 index. When the input DataFrame had a non-zero-based index (`df.tail()`, `df.iloc[]`, or any explicit RangeIndex starting > 0), the `pd.concat([root_keys, values], axis=1)` calls in the per-type `_analyze_*` helpers aligned on incompatible indices and silently produced an all-NaN merge. The downstream groupby then returned an empty `cnt_values` dict and `_reduce_numeric()` hit `sum({}.values()) / 0`, surfacing as a raw `ZeroDivisionError` deep in SDK internals.

Setting `index=df.index` on `root_keys` preserves alignment for every pandas slicing pattern users routinely apply before `synthesize()` — `tail`, `iloc`, and explicit non-zero indices all analyze cleanly.

Regression test: `tests/sdk/test_encoder.py::TestAnalyze::test_non_zero_based_index_does_not_crash` (full suite of test_encoder.py + test_validation_boundary.py: 129/129 passing).