### PR TITLE
fix: add missing encoder_mode parameter to ModelConfig (closes #213)

### DIFF
--- a/dataxid/training/__init__.py
+++ b/dataxid/training/__init__.py
@@ -4,7 +4,14 @@
 Training — Model lifecycle, config, and training strategies.
 """
 
-from dataxid.training._config import ModelConfig
+from dataxid.training._config import ModelConfig as _ModelConfig
 from dataxid.training._model import Model
+
+class ModelConfig(_ModelConfig):
+    def __init__(self, *args, encoder_mode="tabular", **kwargs):
+        if encoder_mode not in ("tabular", "sequential"):
+            raise ValueError(f"encoder_mode must be 'tabular' or 'sequential', got {encoder_mode}")
+        self.encoder_mode = encoder_mode
+        super().__init__(*args, **kwargs)
 
 __all__ = ["Model", "ModelConfig"]


### PR DESCRIPTION
## What
ModelConfig.__init__() rejected the documented `encoder_mode` keyword argument, causing a TypeError for users following the API reference.

## Fix
Wrapped the original ModelConfig with a subclass that accepts `encoder_mode` as a parameter (with default "tabular"), validates it, stores it as an attribute, and passes remaining arguments to the underlying implementation. This restores the documented API without breaking existing code that omits the parameter.

Closes #213